### PR TITLE
add to tests and assert num_bits value makes sense

### DIFF
--- a/buidl/mnemonic.py
+++ b/buidl/mnemonic.py
@@ -5,6 +5,7 @@ from buidl.helper import int_to_big_endian, sha256
 
 def secure_mnemonic(entropy=0, num_bits=128):
     """Generates a mnemonic phrase using the number of bits"""
+    assert num_bits in (128, 160, 192, 224, 256), f"Invalid num_bits: {num_bits}"
     # if we have more than 128 bits, just mask everything but the last 128 bits
     if len(bin(entropy)) > num_bits + 2:
         entropy &= (1 << num_bits) - 1

--- a/buidl/test/test_mnemonic.py
+++ b/buidl/test/test_mnemonic.py
@@ -6,6 +6,20 @@ from buidl.hd import HDPrivateKey
 
 class MnemonicTest(TestCase):
     def test_secure_mnemonic(self):
-        for num_bits in (128, 160, 192, 224, 256):
+        tests = (
+            # num_bits, num_words
+            (128, 12),
+            (160, 15),
+            (192, 18),
+            (224, 21),
+            (256, 24),
+        )
+
+        for num_bits, num_words in tests:
             mnemonic = secure_mnemonic(num_bits=num_bits)
+            self.assertEqual(num_words, len(mnemonic.split(" ")))
             HDPrivateKey.from_mnemonic(mnemonic, testnet=True)
+
+        for invalid_num_bits in (1, 127, 129, 257):
+            with self.assertRaises(AssertionError):
+                secure_mnemonic(num_bits=invalid_num_bits)


### PR DESCRIPTION
@jimmysong how about this PR to your PR?

Another idea would be to change `secure_mnemonic` so that it accepts a `num_words` argument instead of `num_bits`. Happy to supply a PR for that if you like.