### PR TITLE
add better version handling and a helper method for blinding xpubs

### DIFF
--- a/buidl/hd.py
+++ b/buidl/hd.py
@@ -712,15 +712,21 @@ def blind_xpub(starting_xpub, starting_path, secret_path):
     Return the complete (combined) bip32 path, and
     """
 
-    # This will automatically use the version byte that was parsed in the previous step:
-    blinded_child_xpub = HDPublicKey.parse(starting_xpub).traverse(secret_path).xpub()
-    # Note that we cannot verify the starting path, so it is essential that this is accurate
-    complete_blinded_path = combine_bip32_paths(
+    starting_xpub_obj = HDPublicKey.parse(starting_xpub)
+    # Note that we cannot verify the starting path, so it is essential that at least this safety check is accurate
+    if starting_xpub_obj.depth != starting_path.count("/"):
+        raise ValueError(
+            f"starting_xpub_obj.depth {starting_xpub_obj.depth} != starting_path depth {starting_path.count('/')}"
+        )
+
+    # This will automatically use the version byte that was parsed in the previous step
+    blinded_child_xpub = starting_xpub_obj.traverse(secret_path).xpub()
+    blinded_full_path = combine_bip32_paths(
         first_path=starting_path, second_path=secret_path
     )
     return {
         "blinded_child_xpub": blinded_child_xpub,
-        "complete_blinded_path": complete_blinded_path,
+        "blinded_full_path": blinded_full_path,
     }
 
 

--- a/buidl/hd.py
+++ b/buidl/hd.py
@@ -62,6 +62,8 @@ class HDPrivateKey:
         parent_fingerprint=b"\x00\x00\x00\x00",
         child_number=0,
         testnet=False,
+        priv_version=None,
+        pub_version=None,
     ):
         # the main secret, should be a PrivateKey object
         self.private_key = private_key
@@ -75,6 +77,15 @@ class HDPrivateKey:
         # what order child this is
         self.child_number = child_number
         self.testnet = testnet
+
+        if priv_version is None:
+            # Set priv_version based on whether or not we are testnet
+            if testnet is True:
+                priv_version = TESTNET_XPRV
+            else:
+                priv_version = MAINNET_XPRV
+        self.priv_version = priv_version
+
         # keep a copy of the corresponding public key
         self.pub = HDPublicKey(
             point=private_key.point,
@@ -83,6 +94,7 @@ class HDPrivateKey:
             parent_fingerprint=parent_fingerprint,
             child_number=child_number,
             testnet=testnet,
+            pub_version=pub_version,  # HDPublicKey handles the case where pub_version is None
         )
 
     def wif(self):
@@ -116,7 +128,7 @@ class HDPrivateKey:
         return self.xprv()
 
     @classmethod
-    def from_seed(cls, seed, testnet=False):
+    def from_seed(cls, seed, testnet=False, priv_version=None, pub_version=None):
         # get hmac_sha512 with b'Bitcoin seed' and seed
         h = hmac_sha512(b"Bitcoin seed", seed)
         # create the private key using the first 32 bytes in big endian
@@ -128,6 +140,8 @@ class HDPrivateKey:
             private_key=private_key,
             chain_code=chain_code,
             testnet=testnet,
+            priv_version=priv_version,
+            pub_version=pub_version,
         )
 
     def child(self, index):
@@ -168,6 +182,8 @@ class HDPrivateKey:
             parent_fingerprint=parent_fingerprint,
             child_number=child_number,
             testnet=self.testnet,
+            priv_version=self.priv_version,
+            pub_version=self.pub.pub_version,
         )
 
     def traverse(self, path):
@@ -196,10 +212,10 @@ class HDPrivateKey:
         # return the current child
         return current
 
-    def raw_serialize(self, version):
+    def raw_serialize(self, priv_version):
         # version + depth + parent_fingerprint + child number + chain code + private key
-        # start with version, which should be a constant depending on testnet
-        raw = version
+        # start with priv_version, which should be a constant
+        raw = priv_version
         # add depth, which is 1 byte using int_to_byte
         raw += int_to_byte(self.depth)
         # add the parent_fingerprint
@@ -212,23 +228,12 @@ class HDPrivateKey:
         raw += int_to_big_endian(self.private_key.secret, 33)
         return raw
 
-    def _prv(self, version):
-        """Returns the base58-encoded x/y/z prv.
-        Expects a 4-byte version."""
-        raw = self.raw_serialize(version)
-        # return the whole thing base58-encoded
-        return encode_base58_checksum(raw)
-
-    @property
-    def default_version_byte(self):
-        if self.testnet:
-            return TESTNET_XPRV
-        return MAINNET_XPRV
-
     def xprv(self, version=None):
+        """Returns the base58-encoded x/y/z prv."""
         if version is None:
-            version = self.default_version_byte
-        return self._prv(version)
+            version = self.priv_version
+        raw = self.raw_serialize(version)
+        return encode_base58_checksum(raw)
 
     def xpub(self, version=None):
         return self.pub.xpub(version=version)
@@ -253,16 +258,16 @@ class HDPrivateKey:
     @classmethod
     def raw_parse(cls, s):
         """Returns a HDPrivateKey from a stream"""
-        # first 4 bytes are the version
-        version = s.read(4)
-        # check that the version is one of the TESTNET or MAINNET
+        # first 4 bytes are the priv_version
+        priv_version = s.read(4)
+        # check that the priv_version is one of the TESTNET or MAINNET
         #  private keys, if not raise a ValueError
-        if version in ALL_TESTNET_XPRVS:
+        if priv_version in ALL_TESTNET_XPRVS:
             testnet = True
-        elif version in ALL_MAINNET_XPRVS:
+        elif priv_version in ALL_MAINNET_XPRVS:
             testnet = False
         else:
-            raise ValueError(f"not a valid [t-z]prv: {version}")
+            raise ValueError(f"not a valid [t-z]prv: {priv_version}")
         # the next byte is depth
         depth = byte_to_int(s.read(1))
         # next 4 bytes are the parent_fingerprint
@@ -284,6 +289,8 @@ class HDPrivateKey:
             parent_fingerprint=parent_fingerprint,
             child_number=child_number,
             testnet=testnet,
+            priv_version=priv_version,
+            pub_version=priv_version,
         )
 
     def _get_address(self, purpose, account=0, external=True, address=0):
@@ -337,12 +344,33 @@ class HDPrivateKey:
         return self._get_address("84'", account, False, address)
 
     @classmethod
-    def generate(cls, password=b"", extra_entropy=0, testnet=False):
+    def generate(
+        cls,
+        password=b"",
+        extra_entropy=0,
+        testnet=False,
+        priv_version=None,
+        pub_version=None,
+    ):
         mnemonic = secure_mnemonic(extra_entropy=extra_entropy)
-        return mnemonic, cls.from_mnemonic(mnemonic, password=password, testnet=testnet)
+        return mnemonic, cls.from_mnemonic(
+            mnemonic,
+            password=password,
+            testnet=testnet,
+            priv_version=priv_version,
+            pub_version=pub_version,
+        )
 
     @classmethod
-    def from_mnemonic(cls, mnemonic, password=b"", path="m", testnet=False):
+    def from_mnemonic(
+        cls,
+        mnemonic,
+        password=b"",
+        path="m",
+        testnet=False,
+        priv_version=None,
+        pub_version=None,
+    ):
         """Returns a HDPrivateKey object from the mnemonic."""
         # split the mnemonic into words with .split()
         words = mnemonic.split()
@@ -384,12 +412,21 @@ class HDPrivateKey:
         # the seed is the hmac_sha512_kdf with normalized mnemonic and salt
         seed = hmac_sha512_kdf(normalized_mnemonic, salt)
         # return the HDPrivateKey at the path specified
-        return cls.from_seed(seed, testnet=testnet).traverse(path)
+        return cls.from_seed(
+            seed, testnet=testnet, priv_version=priv_version, pub_version=pub_version
+        ).traverse(path)
 
 
 class HDPublicKey:
     def __init__(
-        self, point, chain_code, depth, parent_fingerprint, child_number, testnet=False
+        self,
+        point,
+        chain_code,
+        depth,
+        parent_fingerprint,
+        child_number,
+        testnet=False,
+        pub_version=None,
     ):
         self.point = point
         self.chain_code = chain_code
@@ -397,6 +434,13 @@ class HDPublicKey:
         self.parent_fingerprint = parent_fingerprint
         self.child_number = child_number
         self.testnet = testnet
+        if pub_version is None:
+            # Set pub_version based on whether or not we are testnet
+            if testnet is True:
+                pub_version = TESTNET_XPUB
+            else:
+                pub_version = MAINNET_XPUB
+        self.pub_version = pub_version
         self._raw = None
 
     def __repr__(self):
@@ -460,6 +504,7 @@ class HDPublicKey:
             parent_fingerprint=parent_fingerprint,
             child_number=child_number,
             testnet=self.testnet,
+            pub_version=self.pub_version,
         )
 
     def traverse(self, path):
@@ -484,17 +529,18 @@ class HDPublicKey:
         return current
 
     def raw_serialize(self):
+        # start with pub_version, which should be a constant depending on testnet
         if self._raw is None:
             if self.testnet:
-                version = TESTNET_XPUB
+                pub_version = TESTNET_XPUB
             else:
-                version = MAINNET_XPUB
-            self._raw = self._serialize(version)
+                pub_version = MAINNET_XPUB
+            self._raw = self._serialize(pub_version)
         return self._raw
 
-    def _serialize(self, version):
-        # start with the version
-        raw = version
+    def _serialize(self, pub_version):
+        # start with the pub_version
+        raw = pub_version
         # add the depth using int_to_byte
         raw += int_to_byte(self.depth)
         # add the parent_fingerprint
@@ -507,25 +553,14 @@ class HDPublicKey:
         raw += self.point.sec()
         return raw
 
-    def _pub(self, version):
-        """Returns the base58-encoded x/y/z pub.
-        Expects a 4-byte version."""
+    def xpub(self, version=None):
+        """Returns the base58-encoded x/y/z pub."""
+        if version is None:
+            version = self.pub_version
         # get the serialization
         raw = self._serialize(version)
         # base58-encode the whole thing
         return encode_base58_checksum(raw)
-
-    @property
-    def default_version_byte(self):
-        if self.testnet:
-            return TESTNET_XPUB
-        return MAINNET_XPUB
-
-    def xpub(self, version=None):
-        if version is None:
-            version = self.default_version_byte
-
-        return self._pub(version)
 
     @classmethod
     def parse(cls, s):
@@ -543,16 +578,16 @@ class HDPublicKey:
     @classmethod
     def raw_parse(cls, s):
         """Returns a HDPublicKey from a stream"""
-        # first 4 bytes are the version
-        version = s.read(4)
-        # check that the version is one of the TESTNET or MAINNET
+        # first 4 bytes are the pub_version
+        pub_version = s.read(4)
+        # check that the pub_version is one of the TESTNET or MAINNET
         #  public keys, if not raise a ValueError
-        if version in ALL_TESTNET_XPUBS:
+        if pub_version in ALL_TESTNET_XPUBS:
             testnet = True
-        elif version in ALL_MAINNET_XPUBS:
+        elif pub_version in ALL_MAINNET_XPUBS:
             testnet = False
         else:
-            raise ValueError("not a valid [t-z]pub version: {version}")
+            raise ValueError("not a valid [t-z]pub pub_version: {pub_version}")
         # the next byte is depth
         depth = byte_to_int(s.read(1))
         # next 4 bytes are the parent_fingerprint
@@ -571,6 +606,7 @@ class HDPublicKey:
             parent_fingerprint=parent_fingerprint,
             child_number=child_number,
             testnet=testnet,
+            pub_version=pub_version,
         )
 
 
@@ -648,6 +684,44 @@ def ltrim_path(bip32_path, depth):
 
     to_return = path.split("/")[depth + 1 :]
     return "m/" + "/".join(to_return)
+
+
+def combine_bip32_paths(first_path, second_path):
+    for bip32_path in (first_path, second_path):
+        if not is_valid_bip32_path(bip32_path):
+            raise ValueError(f"Invalid bip32 path: {bip32_path}")
+
+    # be forgiving
+    first_path = first_path.lower().strip().replace("'", "h").replace("//", "/")
+    second_path = second_path.lower().strip().replace("'", "h").replace("//", "/")
+
+    if first_path == "m":
+        return second_path
+
+    if second_path == "m":
+        return first_path
+
+    # Trim of leading "m/" from second path:
+    return f"{first_path}/{second_path[2:]}"
+
+
+def blind_xpub(starting_xpub, starting_path, secret_path):
+    """
+    Blind a starting_xpub with a given (and unverifiable) path, using a secret path.
+
+    Return the complete (combined) bip32 path, and
+    """
+
+    # This will automatically use the version byte that was parsed in the previous step:
+    blinded_child_xpub = HDPublicKey.parse(starting_xpub).traverse(secret_path).xpub()
+    # Note that we cannot verify the starting path, so it is essential that this is accurate
+    complete_blinded_path = combine_bip32_paths(
+        first_path=starting_path, second_path=secret_path
+    )
+    return {
+        "blinded_child_xpub": blinded_child_xpub,
+        "complete_blinded_path": complete_blinded_path,
+    }
 
 
 def parse_key_record(key_record_str):

--- a/buidl/test/test_hd.py
+++ b/buidl/test/test_hd.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 
 from buidl.hd import (
+    blind_xpub,
+    combine_bip32_paths,
     calc_num_valid_seedpicker_checksums,
     calc_valid_seedpicker_checksums,
     generate_wshsortedmulti_address,
@@ -527,6 +529,8 @@ class BIP32PathsTest(TestCase):
     def test_invalid_paths(self):
         # just "m" (without trailing slash) is valid:
         self.assertFalse(is_valid_bip32_path("m/"))
+        self.assertFalse(is_valid_bip32_path("m/1/"))
+        self.assertFalse(is_valid_bip32_path("m/1'/"))
         self.assertFalse(is_valid_bip32_path("m/-1"))
         self.assertFalse(is_valid_bip32_path("m/1/a"))
         self.assertFalse(is_valid_bip32_path("m/foo"))
@@ -622,3 +626,85 @@ class OutputRecordTest(TestCase):
 
         receive_addrs = list(generate_wshsortedmulti_address(**kwargs, is_change=False))
         self.assertEqual(receive_addrs, expected_receive_addrs)
+
+
+class BlindingTest(TestCase):
+    def test_combine_paths(self):
+        self.assertEqual(combine_bip32_paths("m/1", "m/2/3"), "m/1/2/3")
+        self.assertEqual(
+            combine_bip32_paths("m/48h/1h/0h/2h", "m/1/2/3/4/5"),
+            "m/48h/1h/0h/2h/1/2/3/4/5",
+        )
+        self.assertEqual(combine_bip32_paths("m", "m/1"), "m/1")
+        self.assertEqual(combine_bip32_paths("m/1", "m"), "m/1")
+        self.assertEqual(combine_bip32_paths("m", "m"), "m")
+
+    def test_combine_paths_error(self):
+        with self.assertRaises(ValueError):
+            combine_bip32_paths("m/foo", "m/1/2/3")
+            combine_bip32_paths("m/1/2/3", "m/foo")
+
+    def test_blind_vpub(self):
+        # All test vectors below compared manually to https://iancoleman.io/bip39/ and then converted with https://jlopp.github.io/xpub-converter/
+        starting_path = "m/48h/1h/0h/2h"
+        starting_vpub = (
+            HDPrivateKey.from_mnemonic("oil " * 12)
+            .traverse(starting_path)
+            .xpub(bytes.fromhex("02575483"))
+        )  # Vpub version bytes
+        self.assertEqual(
+            starting_vpub,
+            "Vpub5mvQbnmqKfpPjWfAZEw5Xjdr6UjnjyZEirzrhNMSuKjL8Qfd3nqLBkrBrVXNeMgKCjPXbyLnSCn6qcD8fHQCkNnNLnkpQtY3sh4MHmywvbe",
+        )
+        secret_path = "m/920870093/318569592/821713943/1914815254/1398142787/9"  # randomly generated
+        have = blind_xpub(
+            starting_xpub=starting_vpub,
+            starting_path=starting_path,
+            secret_path=secret_path,
+        )
+        want = {
+            "complete_blinded_path": "m/48h/1h/0h/2h/920870093/318569592/821713943/1914815254/1398142787/9",
+            "blinded_child_xpub": "Vpub5xWzaq6Ya7K9Y2UeFyL8SfHhydnp5FZDskm9mkAfUppkXVJDKrnLxU2Ezd55k8RSzSf4YETJj982NJQGCSzKJxUa6oQmbe1HWTRavCRzzxj",
+        }
+        self.assertEqual(have, want)
+
+    def test_blind_xpub(self):
+        # All test vectors below compared manually to https://iancoleman.io/bip39/
+
+        starting_path = "m"
+        root_xpub = (
+            HDPrivateKey.from_mnemonic("bacon " * 24).traverse(starting_path).xpub()
+        )
+        self.assertEqual(
+            root_xpub,
+            "xpub661MyMwAqRbcGMzZtBZrKWaDMAQKjd5bMSnHr8qBfCz5zMwZEuajnc8cxjsEUECAZDeDC7s4zbT3Z9KrrM9wJ3MaT6sH9eRYxLY1BNf45BF",
+        )
+        secret_path = "m/1/2/3/4/5/6/7/8/9"
+        have = blind_xpub(
+            starting_xpub=root_xpub, starting_path="m", secret_path=secret_path
+        )
+        want = {
+            "complete_blinded_path": secret_path,  # the same since we started with the root path
+            "blinded_child_xpub": "xpub6QbmAk7amacgfQVY3aTAiqhM1okb4Gi3EFzBJQMEja1uU4gZvG9vwiExr2C1ryZqnyczTvvaNhw63UALmXGkFo7FHhajX8SNimgK3zu3tp5",
+        }
+        self.assertEqual(have, want)
+
+        starting_path = "m/48h/0h/0h/2h"
+        child_xpub = (
+            HDPrivateKey.from_mnemonic("bacon " * 24).traverse(starting_path).xpub()
+        )
+        self.assertEqual(
+            child_xpub,
+            "xpub6EeqK2JLwngrHJEQ4X4iqrySZV9qU3TgwMgf6NStLZa37AfNiHTtTE9ji1F9YQDLArJMLy8sw3Q2samVj5VQQjaaUHr5z2Hz57NWHJCfh31",
+        )
+        secret_path = "m/920870093/318569592/821713943/1914815254/1398142787/9"  # randomly generated
+        have = blind_xpub(
+            starting_xpub=child_xpub,
+            starting_path=starting_path,
+            secret_path=secret_path,
+        )
+        want = {
+            "complete_blinded_path": "m/48h/0h/0h/2h/920870093/318569592/821713943/1914815254/1398142787/9",
+            "blinded_child_xpub": "xpub6SDyub38LYeUd211VxRZCiVnU4fSr4ZwPssFGMxyyXjZ6EvrA4ZkZhp4f9My2qzqSJFHxkAv8ctaGipx7UM6sCzmso7wxiohHBhcBs7ipWz",
+        }
+        self.assertEqual(have, want)

--- a/buidl/test/test_hd.py
+++ b/buidl/test/test_hd.py
@@ -631,6 +631,7 @@ class OutputRecordTest(TestCase):
 class BlindingTest(TestCase):
     def test_combine_paths(self):
         self.assertEqual(combine_bip32_paths("m/1", "m/2/3"), "m/1/2/3")
+        self.assertEqual(combine_bip32_paths("m/1h", "m/2/3"), "m/1h/2/3")
         self.assertEqual(
             combine_bip32_paths("m/48h/1h/0h/2h", "m/1/2/3/4/5"),
             "m/48h/1h/0h/2h/1/2/3/4/5",
@@ -644,14 +645,15 @@ class BlindingTest(TestCase):
             combine_bip32_paths("m/foo", "m/1/2/3")
             combine_bip32_paths("m/1/2/3", "m/foo")
 
-    def test_blind_vpub(self):
+    def test_blind_m48_vpub(self):
         # All test vectors below compared manually to https://iancoleman.io/bip39/ and then converted with https://jlopp.github.io/xpub-converter/
         starting_path = "m/48h/1h/0h/2h"
+        # Vpub version bytes
         starting_vpub = (
             HDPrivateKey.from_mnemonic("oil " * 12)
             .traverse(starting_path)
             .xpub(bytes.fromhex("02575483"))
-        )  # Vpub version bytes
+        )
         self.assertEqual(
             starting_vpub,
             "Vpub5mvQbnmqKfpPjWfAZEw5Xjdr6UjnjyZEirzrhNMSuKjL8Qfd3nqLBkrBrVXNeMgKCjPXbyLnSCn6qcD8fHQCkNnNLnkpQtY3sh4MHmywvbe",
@@ -663,18 +665,43 @@ class BlindingTest(TestCase):
             secret_path=secret_path,
         )
         want = {
-            "complete_blinded_path": "m/48h/1h/0h/2h/920870093/318569592/821713943/1914815254/1398142787/9",
+            "blinded_full_path": "m/48h/1h/0h/2h/920870093/318569592/821713943/1914815254/1398142787/9",
             "blinded_child_xpub": "Vpub5xWzaq6Ya7K9Y2UeFyL8SfHhydnp5FZDskm9mkAfUppkXVJDKrnLxU2Ezd55k8RSzSf4YETJj982NJQGCSzKJxUa6oQmbe1HWTRavCRzzxj",
         }
         self.assertEqual(have, want)
 
-    def test_blind_xpub(self):
+    def test_blind_m48_xpub(self):
+        # All test vectors below compared manually to https://iancoleman.io/bip39/ and then converted with https://jlopp.github.io/xpub-converter/
+        starting_path = "m/48h/0h/0h/2h"
+        starting_xpub = (
+            HDPrivateKey.from_mnemonic("oil " * 12).traverse(starting_path).xpub()
+        )
+
+        self.assertEqual(
+            starting_xpub,
+            "xpub6F8WgTkiV8iDPFG1Kv4sNrcBNMMgKK4cjfxjdZWvR3kChfbt3L2dJF7xmCHBMGMmxjyzwgjdFkh9UN3623YpsmqN1KwZGR45Y3ANLQQX87u",
+        )
+        secret_path = "m/920870093/318569592/821713943/1914815254/1398142787/9"  # randomly generated
+        have = blind_xpub(
+            starting_xpub=starting_xpub,
+            starting_path=starting_path,
+            secret_path=secret_path,
+        )
+        want = {
+            "blinded_full_path": "m/48h/0h/0h/2h/920870093/318569592/821713943/1914815254/1398142787/9",
+            "blinded_child_xpub": "xpub6RKvkus7fgUnP2trNVo2N1jaQeGPBHCV9m63Jaje8EW2Ry5KjYySb1tbPSi3E7Vh6ZzxRn15hUmBg5KmSaQvKjZmTvXKQnRPXcoJS9PXkiS",
+        }
+        self.assertEqual(have, want)
+
+    def test_blind_root_xpub(self):
         # All test vectors below compared manually to https://iancoleman.io/bip39/
 
         starting_path = "m"
+        # The .traverse() here does nothing and is optional, just here for consistency/clarity:
         root_xpub = (
             HDPrivateKey.from_mnemonic("bacon " * 24).traverse(starting_path).xpub()
         )
+
         self.assertEqual(
             root_xpub,
             "xpub661MyMwAqRbcGMzZtBZrKWaDMAQKjd5bMSnHr8qBfCz5zMwZEuajnc8cxjsEUECAZDeDC7s4zbT3Z9KrrM9wJ3MaT6sH9eRYxLY1BNf45BF",
@@ -684,7 +711,7 @@ class BlindingTest(TestCase):
             starting_xpub=root_xpub, starting_path="m", secret_path=secret_path
         )
         want = {
-            "complete_blinded_path": secret_path,  # the same since we started with the root path
+            "blinded_full_path": secret_path,  # the same since we started with the root path
             "blinded_child_xpub": "xpub6QbmAk7amacgfQVY3aTAiqhM1okb4Gi3EFzBJQMEja1uU4gZvG9vwiExr2C1ryZqnyczTvvaNhw63UALmXGkFo7FHhajX8SNimgK3zu3tp5",
         }
         self.assertEqual(have, want)
@@ -704,7 +731,17 @@ class BlindingTest(TestCase):
             secret_path=secret_path,
         )
         want = {
-            "complete_blinded_path": "m/48h/0h/0h/2h/920870093/318569592/821713943/1914815254/1398142787/9",
+            "blinded_full_path": "m/48h/0h/0h/2h/920870093/318569592/821713943/1914815254/1398142787/9",
             "blinded_child_xpub": "xpub6SDyub38LYeUd211VxRZCiVnU4fSr4ZwPssFGMxyyXjZ6EvrA4ZkZhp4f9My2qzqSJFHxkAv8ctaGipx7UM6sCzmso7wxiohHBhcBs7ipWz",
         }
         self.assertEqual(have, want)
+
+    def test_bad_depth(self):
+        starting_path = "m/48h/0h/0h/2h"
+        starting_xpub = (
+            HDPrivateKey.from_mnemonic("bacon " * 24).traverse(starting_path).xpub()
+        )
+        with self.assertRaises(ValueError):
+            blind_xpub(
+                starting_xpub=starting_xpub, starting_path="m/1", secret_path="m/999"
+            )


### PR DESCRIPTION
One of the main drivers of this was that if you parse a Vpub like `Vpub5mvQbnmqKfpPjWfAZEw5Xjdr6UjnjyZEirzrhNMSuKjL8Qfd3nqLBkrBrVXNeMgKCjPXbyLnSCn6qcD8fHQCkNnNLnkpQtY3sh4MHmywvbe`, `traverse()` it and then return the resulting `xpub()`, you will lose your version byte and display an `xpub` instead of a `Vpub`.

One day this won't matter as slip132 will be deprecated, but for now these version bytes are still essential. Software like Specter-Desktop decides on the use of a key (p2wsh) and network (main/test) based on the version byte, and application developers shouldn't need to even know things like that.

Also, there's some general cleanup this enables, like getting rid of the `default_version_byte()` `@proprerty` and collapses the `_prv`/`_pub` methods.