### PR TITLE
add missing import, improve shamir testing in multiwallet

### DIFF
--- a/buidl/__init__.py
+++ b/buidl/__init__.py
@@ -14,5 +14,6 @@ from .op import *
 from .pbkdf2 import *
 from .psbt import *
 from .script import *
+from .shamir import *
 from .tx import *
 from .witness import *

--- a/multiwallet.py
+++ b/multiwallet.py
@@ -622,7 +622,9 @@ class MyPrompt(Cmd):
             if cnt % 10 == 0:
                 print(".", end="", flush=True)
 
-        print_yellow(f"\nSuccesfully tested {'ALL ' if testing_limit == 12870 else ''}{cnt} combinations")
+        print_yellow(
+            f"\nSuccesfully tested {'ALL ' if testing_limit == 12870 else ''}{cnt} combinations"
+        )
 
         print("\n")
         share_mnemonics = "\n\n".join(shares)

--- a/multiwallet.py
+++ b/multiwallet.py
@@ -9,7 +9,6 @@ from itertools import combinations
 from os import environ
 from platform import platform
 from pkg_resources import DistributionNotFound, get_distribution
-from random import sample
 
 import buidl  # noqa: F401 (used below with pkg_resources for versioning)
 from buidl.blinding import blind_xpub, secure_secret_path
@@ -611,7 +610,6 @@ class MyPrompt(Cmd):
         print_yellow(
             "Testing share combinations to be certain they will recover your seed phrase"
         )
-        all_combos = list()
         for cnt, combo in enumerate(combinations(shares, k)):
             if cnt > testing_limit:
                 break

--- a/multiwallet.py
+++ b/multiwallet.py
@@ -611,15 +611,18 @@ class MyPrompt(Cmd):
         print_yellow(
             "Testing share combinations to be certain they will recover your seed phrase"
         )
-        all_combos = list(combinations(shares, k))
-        combos = sample(all_combos, min(testing_limit, len(all_combos)))
-        for cnt, combo in enumerate(combos):
+        all_combos = list()
+        for cnt, combo in enumerate(combinations(shares, k)):
+            if cnt > testing_limit:
+                break
             calculated = ShareSet.recover_mnemonic(combo, passphrase)
             if calculated != mnemonic:
                 # we should never reach this line
                 raise RuntimeError(f"Bad shares {calculated} for mnemonic {mnemonic}")
-            if cnt % 10:
+            if cnt % 10 == 0:
                 print(".", end="", flush=True)
+
+        print_yellow(f"\nSuccesfully tested {'ALL ' if testing_limit == 12870 else ''}{cnt} combinations")
 
         print("\n")
         share_mnemonics = "\n\n".join(shares)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="buidl",
-    version="0.2.12",
+    version="0.2.13",
     author="Example Author",
     author_email="author@example.com",
     description="An easy-to-use and fully featured bitcoin library written in pure python (no dependencies).",


### PR DESCRIPTION
Shamir testing now does the following:
* Defaults to testing all permutations. Call me crazy, but if you're going through the headache of setting up a giant SSSS (8-of-16), you want to be sure that every combo works. I buried restrictions (with your old defaults) in the advanced section.
*When testing a subset, it randomizes which ones to test. Shouldn't matter, but I wanted to be extra sure.