### PR TITLE
package neccesary txt data into pypi repo

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include buidl/bip39_words.txt
+include buidl/slip39_words.txt

--- a/clean.sh
+++ b/clean.sh
@@ -1,3 +1,6 @@
+#! /usr/bin/env bash
+
+set -o xtrace
 rm -rf .venv3/
 rm -rf dist/
 rm -rf build/

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 from setuptools import setup, find_packages
 
+
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
     name="buidl",
-    version="0.2.13",
+    version="0.2.14",
     author="Example Author",
     author_email="author@example.com",
     description="An easy-to-use and fully featured bitcoin library written in pure python (no dependencies).",
@@ -13,6 +14,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/buidl-bitcoin/buidl-python",
     packages=find_packages(),
+    include_package_data=True,  # https://stackoverflow.com/a/56689053
     scripts=["multiwallet.py"],  # hack to not require installation
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
@jimmysong the PR moving mnemonic words to a txt file broke `buidl` (`FileNotFoundError`) on pypi, this appears to fix it.

I tested it on PyPi's test repo ([ephemeral link](https://test.pypi.org/project/buidl/0.2.13/)) so this *should* work on regular pypi.

I'm going to emergency merge this in now, happy to make changes if you disagree.