### PR TITLE
enforce valid paths on traverse method

### DIFF
--- a/buidl/hd.py
+++ b/buidl/hd.py
@@ -192,6 +192,9 @@ class HDPrivateKey:
         # accept path in uppercase and/or using h instead of '
         path = path.lower().replace("h", "'")
 
+        if not path.startswith("m"):
+            raise ValueError(f"Invalid Path: {path}")
+
         # keep track of the current node starting with self
         current = self
         # split up the path by the '/' splitter, ignore the first
@@ -488,6 +491,9 @@ class HDPublicKey:
     def traverse(self, path):
         """Returns the HDPublicKey at the path indicated.
         Path should be in the form of m/x/y/z."""
+
+        if not path.startswith("m"):
+            raise ValueError(f"Invalid Path: {path}")
 
         # accept path in uppercase and/or using h instead of '
         path = path.lower().replace("h", "'")

--- a/buidl/test/test_hd.py
+++ b/buidl/test/test_hd.py
@@ -400,7 +400,7 @@ class HDTest(TestCase):
         self.assertEqual(account0.xprv(), want)
         account0_pub = account0.pub
         account0_first_key = account0.child(0).child(0)
-        pub_first_key = account0_pub.traverse("/0/0")
+        pub_first_key = account0_pub.traverse("m/0/0")
         want = "cULrpoZGXiuC19Uhvykx7NugygA3k86b3hmdCeyvHYQZSxojGyXJ"
         self.assertEqual(account0_first_key.wif(), want)
         want = 0xC9BDB49CFBAEDCA21C4B1F3A7803C34636B1D7DC55A717132443FC3F4C5867E8

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="buidl",
-    version="0.2.15",
+    version="0.2.16",
     author="Example Author",
     author_email="author@example.com",
     description="An easy-to-use and fully featured bitcoin library written in pure python (no dependencies).",


### PR DESCRIPTION
Otherwise, you can get weird outcomes like this:
```
>>> HDPrivateKey.from_mnemonic("invest " * 12).traverse("m/48h/1h/0h/2h")
xprvA1CSTHGqn9kfpW9qSZa9EHXofAfQat2y48Rn7BUbWguLsfwXK3BMvH2YN6XgzQGCKLxY2xAH3xawihSEXHRpoZmfQLAfMqd3C3jKjLeUJTN

>>> HDPrivateKey.from_mnemonic("invest " * 12).traverse("48h/1h/0h/2h")
xprv9zHDEJELaVWXm9zFDTkiN5LK1AnkwZoJrXJnbLXDoEtFYXuBXpKfk518dSmbwJa9HVFLzK4k3vTwP7BKthWC9apZk5AqAqKsxEj61Efk8eF
```