### PR TITLE
add singlesweep as script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="buidl",
-    version="0.2.16",
+    version="0.2.17",
     author="Example Author",
     author_email="author@example.com",
     description="An easy-to-use and fully featured bitcoin library written in pure python (no dependencies).",
@@ -15,7 +15,7 @@ setup(
     url="https://github.com/buidl-bitcoin/buidl-python",
     packages=find_packages(),
     include_package_data=True,  # https://stackoverflow.com/a/56689053
-    scripts=["multiwallet.py"],  # hack to not require installation
+    scripts=["multiwallet.py", "singlesweep.py"],  # hack to not require installation
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Works on test pypi:
```
$ pip install -i https://test.pypi.org/simple/ buidl
Looking in indexes: https://test.pypi.org/simple/
Collecting buidl
  Downloading https://test-files.pythonhosted.org/packages/36/fc/a75165963101d771e8c698ca126afb7389d35d256d7693bc18078fafcd64/buidl-0.2.17-py3-none-any.whl (186 kB)
     |████████████████████████████████| 186 kB 1.2 MB/s 
Installing collected packages: buidl
Successfully installed buidl-0.2.17

$ singlesweep.py 
Welcome to singlesweep, a stateless single sig sweeper that works with WIF and PSBTs.
Single sig is DANGEROUS, this is an emergency recovery tool with NO WARRANTY OF ANY KIND.
It is often used for collecting funds from old paper wallets.
Type help or ? to list commands.
```