### PR TITLE
add generate_p2wsh_key_record convenience method

### DIFF
--- a/buidl/descriptor.py
+++ b/buidl/descriptor.py
@@ -182,6 +182,11 @@ class P2WSHSortedMulti:
             xpub_parent = key_record.get("xpub_parent")
             try:
                 hdpubkey_obj = HDPublicKey.parse(xpub_parent)
+                # get rid of slip132 version byte (if it exists) as this will alter the checksum calculation
+                hdpubkey_obj_attrs = vars(hdpubkey_obj)
+                del hdpubkey_obj_attrs["pub_version"]
+                del hdpubkey_obj_attrs["_raw"]
+                xpub_to_use = HDPublicKey(**hdpubkey_obj_attrs).xpub()
             except ValueError:
                 raise ValueError(
                     f"Invalid xpub_parent `{xpub_parent}` in key record: {key_record}"
@@ -201,12 +206,12 @@ class P2WSHSortedMulti:
                 {
                     "path": path,
                     "xfp": xfp_hex,
-                    "xpub_parent": xpub_parent,
+                    "xpub_parent": xpub_to_use,
                     "account_index": account_index,
                 }
             )
 
-            descriptor_text += f",[{key_record['xfp']}{key_record['path'][1:]}]{key_record['xpub_parent']}/{account_index}/*"
+            descriptor_text += f",[{key_record['xfp']}{key_record['path'][1:]}]{xpub_to_use}/{account_index}/*"
 
         descriptor_text += "))"
         self.descriptor_text = descriptor_text

--- a/buidl/test/test_descriptor.py
+++ b/buidl/test/test_descriptor.py
@@ -177,6 +177,30 @@ class P2WSHMultiTest(TestCase):
             else:
                 self.assertNotEqual(sorted_addr, unsorted_addr)
 
+    def test_mixed_slip132_p2wsh_sortedmulti(self):
+        # this should coalesce the values into non-slip132 (p2wsh sortedmulti already conveys the script type unambiguously)
+        quorum_m = 1
+        key_records = [
+            {
+                # investx12:
+                "xfp": "aa917e75",
+                "path": "m/48h/1h/0h/2h",
+                "xpub_parent": "tpubDEZRP2dRKoGRJnR9zn6EoLouYKbYyjFsxywgG7wMQwCDVkwNvoLhcX1rTQipYajmTAF82kJoKDiNCgD4wUPahACE7n1trMSm7QS8B3S1fdy",
+                "account_index": 0,
+            },
+            {
+                # sellx12:
+                "xfp": "2553c4b8",
+                "path": "m/48h/1h/0h/2h/2046266013/1945465733/1801020214/1402692941",
+                "xpub_parent": "Vpub5uMrp2GYpnHN8BkjvXpP71TuZ8BDqu61PPcwEKSzE9Mcuow727mUJNsDsKdzAiupHXea5F7ZxD9SaSQvbr1hvpNjrijJQ2J46VQjc5yEcm8",
+                "account_index": 0,
+            },
+        ]
+        p2wsh_sortedmulti_obj = P2WSHSortedMulti(quorum_m, key_records)
+        # notice that both values are tpub, despite ingesting Vpub
+        want = "wsh(sortedmulti(1,[aa917e75/48h/1h/0h/2h]tpubDEZRP2dRKoGRJnR9zn6EoLouYKbYyjFsxywgG7wMQwCDVkwNvoLhcX1rTQipYajmTAF82kJoKDiNCgD4wUPahACE7n1trMSm7QS8B3S1fdy/0/*,[2553c4b8/48h/1h/0h/2h/2046266013/1945465733/1801020214/1402692941]tpubDNVvpMhdGTmQg1AT6muju2eUWPXWWAtUSyc1EQ2MxJ2s97fMqFZQbpzQM4gU8bwzfFM7KBpSXRJ5v2Wu8sY2GF5ZpXm3qy8GLArZZNM1Wru/0/*))#0lfdttke"
+        self.assertEqual(str(p2wsh_sortedmulti_obj), want)
+
     def test_invalid_p2wsh_sortedmulti(self):
         # Notice the mix of xpub and tpub
         output_record = """wsh(sortedmulti(1,[c7d0648a/48h/1h/0h/2h]tpubDEpefcgzY6ZyEV2uF4xcW2z8bZ3DNeWx9h2BcwcX973BHrmkQxJhpAXoSWZeHkmkiTtnUjfERsTDTVCcifW6po3PFR1JRjUUTJHvPpDqJhr/0/*,[12980eed/48h/1h/0h/2h]xpub6ENtkZb1q4JLHBocpPeoQj8xGsQ1Y7Jnkc3Vm43LyPaQ7BfzkDeF3fzxt78SBELXc2PUNHPuVEdTaukwNRqqc8xFKjVXfQ4FpN6eKqe6y9E/0/*))#tatkmj5q"""

--- a/buidl/test/test_hd.py
+++ b/buidl/test/test_hd.py
@@ -547,11 +547,15 @@ class HDTest(TestCase):
         hdpriv_obj = HDPrivateKey.from_mnemonic(seed_phrase)
         want = "[5436d724/48h/0h/0h/2h]Zpub74fkz9VnCkwXHqheLbKfBEPKPfnFg3S1Ecn7Jx4HgBWwD1FS5VLMtFYNqLmFBVifGuXKz2nirv647gFYCinhBSdBqrrh5vq8ok8m2eaRAt7"
         self.assertEqual(hdpriv_obj.generate_p2wsh_key_record(), want)
+        want = "[5436d724/48h/0h/0h/2h]xpub6E79FaRWLSJCAgA2jDHRvyrWKwT6aSmR685zptzyYPvmUd44omcxZ1NAzDtbdFBvEADjcVbV4NzTDwQeU6oiSV9KGiMSWhjANZjbfUHkm3Y"
+        self.assertEqual(hdpriv_obj.generate_p2wsh_key_record(use_slip132_version_byte=False), want)
 
         # testnet
         hdpriv_obj = HDPrivateKey.from_mnemonic(seed_phrase, testnet=True)
         want = "[5436d724/48h/1h/0h/2h]Vpub5ncJ4gVToMcTWjG4shBZHeeCUXhX5r86W9cwggqw1m6aojbrHxr9yJFsoXaiXrBfAzV3TaVyxCB6EYUW21SVayfcAhiVc9XRJS1WL4Gh9td"
         self.assertEqual(hdpriv_obj.generate_p2wsh_key_record(), want)
+        want = "[5436d724/48h/1h/0h/2h]tpubDFkN51vYF36W4Yfn3wGv5fpmRo3ok7vZZjc1gmRJjumq33L776e6GkP4HGdCVjDqYiBahXCrXQKja8aUZ2xovQNS8WkF46MdY7TLHJLYD7H"
+        self.assertEqual(hdpriv_obj.generate_p2wsh_key_record(use_slip132_version_byte=False), want)
 
 
 class BIP32PathsTest(TestCase):

--- a/buidl/test/test_hd.py
+++ b/buidl/test/test_hd.py
@@ -474,9 +474,11 @@ class HDTest(TestCase):
 
     def test_from_mnemonic_errors(self):
         with self.assertRaises(InvalidBIP39Length):
+            # only 1 word!
             HDPrivateKey.from_mnemonic("hello")
 
         with self.assertRaises(InvalidChecksumWordsError):
+            # 12 words (11 would work)
             mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon"
             HDPrivateKey.from_mnemonic(mnemonic)
 
@@ -536,6 +538,20 @@ class HDTest(TestCase):
         self.assertEqual(recreated_obj.xpub(), xpub)
         # Confirm the version bytes have passed through correctly to the HDPublicKey object:
         self.assertEqual(recreated_obj.pub.xpub(), xpub)
+
+    def test_key_record(self):
+        # Matched against seedpicker.net on 2021-06-04
+        seed_phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art"
+
+        # mainnet
+        hdpriv_obj = HDPrivateKey.from_mnemonic(seed_phrase)
+        want = "[5436d724/48h/0h/0h/2h]Zpub74fkz9VnCkwXHqheLbKfBEPKPfnFg3S1Ecn7Jx4HgBWwD1FS5VLMtFYNqLmFBVifGuXKz2nirv647gFYCinhBSdBqrrh5vq8ok8m2eaRAt7"
+        self.assertEqual(hdpriv_obj.generate_p2wsh_key_record(), want)
+
+        # testnet
+        hdpriv_obj = HDPrivateKey.from_mnemonic(seed_phrase, testnet=True)
+        want = "[5436d724/48h/1h/0h/2h]Vpub5ncJ4gVToMcTWjG4shBZHeeCUXhX5r86W9cwggqw1m6aojbrHxr9yJFsoXaiXrBfAzV3TaVyxCB6EYUW21SVayfcAhiVc9XRJS1WL4Gh9td"
+        self.assertEqual(hdpriv_obj.generate_p2wsh_key_record(), want)
 
 
 class BIP32PathsTest(TestCase):

--- a/buidl/test/test_hd.py
+++ b/buidl/test/test_hd.py
@@ -548,14 +548,18 @@ class HDTest(TestCase):
         want = "[5436d724/48h/0h/0h/2h]Zpub74fkz9VnCkwXHqheLbKfBEPKPfnFg3S1Ecn7Jx4HgBWwD1FS5VLMtFYNqLmFBVifGuXKz2nirv647gFYCinhBSdBqrrh5vq8ok8m2eaRAt7"
         self.assertEqual(hdpriv_obj.generate_p2wsh_key_record(), want)
         want = "[5436d724/48h/0h/0h/2h]xpub6E79FaRWLSJCAgA2jDHRvyrWKwT6aSmR685zptzyYPvmUd44omcxZ1NAzDtbdFBvEADjcVbV4NzTDwQeU6oiSV9KGiMSWhjANZjbfUHkm3Y"
-        self.assertEqual(hdpriv_obj.generate_p2wsh_key_record(use_slip132_version_byte=False), want)
+        self.assertEqual(
+            hdpriv_obj.generate_p2wsh_key_record(use_slip132_version_byte=False), want
+        )
 
         # testnet
         hdpriv_obj = HDPrivateKey.from_mnemonic(seed_phrase, testnet=True)
         want = "[5436d724/48h/1h/0h/2h]Vpub5ncJ4gVToMcTWjG4shBZHeeCUXhX5r86W9cwggqw1m6aojbrHxr9yJFsoXaiXrBfAzV3TaVyxCB6EYUW21SVayfcAhiVc9XRJS1WL4Gh9td"
         self.assertEqual(hdpriv_obj.generate_p2wsh_key_record(), want)
         want = "[5436d724/48h/1h/0h/2h]tpubDFkN51vYF36W4Yfn3wGv5fpmRo3ok7vZZjc1gmRJjumq33L776e6GkP4HGdCVjDqYiBahXCrXQKja8aUZ2xovQNS8WkF46MdY7TLHJLYD7H"
-        self.assertEqual(hdpriv_obj.generate_p2wsh_key_record(use_slip132_version_byte=False), want)
+        self.assertEqual(
+            hdpriv_obj.generate_p2wsh_key_record(use_slip132_version_byte=False), want
+        )
 
 
 class BIP32PathsTest(TestCase):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="buidl",
-    version="0.2.17",
+    version="0.2.18",
     author="Example Author",
     author_email="author@example.com",
     description="An easy-to-use and fully featured bitcoin library written in pure python (no dependencies).",


### PR DESCRIPTION
It's great having test coverage (albeit outside of github CI) for multiwallet:
```
$ git log -1
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
commit b0a61b9e6d4025fe3b9eb2c6dcb6c908921ed7f2 (HEAD -> generate_p2wsh_key_record, origin/generate_p2wsh_key_record) ┃
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Author: Michael Flaxman <mflaxman@gmail.com>
Date:   Fri Jun 4 11:17:23 2021 -0600

    add generate_p2wsh_key_record convenience method and update multiwallet to use that
```

```
$ pytest test_*.py -v
==================================================================== test session starts ====================================================================
platform darwin -- Python 3.9.0, pytest-6.1.1, py-1.10.0, pluggy-0.13.1 -- /Users/mflaxman/.pyenv/versions/3.9.0/bin/python3
cachedir: .pytest_cache
rootdir: /Users/mflaxman/workspace/buidl-python
collected 10 items                                                                                                                                          

test_multiwallet.py::MultiwalletTest::test_change_addr PASSED                                                                                         [ 10%]
test_multiwallet.py::MultiwalletTest::test_debug PASSED                                                                                               [ 20%]
test_multiwallet.py::MultiwalletTest::test_fail PASSED                                                                                                [ 30%]
test_multiwallet.py::MultiwalletTest::test_receive_addr PASSED                                                                                        [ 40%]
test_multiwallet.py::MultiwalletTest::test_seedpicker_basic PASSED                                                                                    [ 50%]
test_multiwallet.py::MultiwalletTest::test_sign_tx PASSED                                                                                             [ 60%]
test_singlesweep.py::SinglesweepTest::test_debug PASSED                                                                                               [ 70%]
test_singlesweep.py::SinglesweepTest::test_fail PASSED                                                                                                [ 80%]
test_singlesweep.py::SinglesweepTest::test_send_compressed PASSED                                                                                     [ 90%]
test_singlesweep.py::SinglesweepTest::test_send_uncompressed PASSED                                                                                   [100%]

==================================================================== 10 passed in 9.97s =====================================================================
```