### PR TITLE
RIP slip132 as default

### DIFF
--- a/buidl/hd.py
+++ b/buidl/hd.py
@@ -395,11 +395,11 @@ class HDPrivateKey:
         mnemonic = ShareSet.recover_mnemonic(share_mnemonics, passphrase)
         return cls.from_mnemonic(mnemonic, password, path, testnet)
 
-    def generate_p2wsh_key_record(self, bip32_path=None, use_slip132_version_byte=True):
+    def generate_p2wsh_key_record(
+        self, bip32_path=None, use_slip132_version_byte=False
+    ):
         """
         Convenience method for generating a public key_record to supply to your Coordinator software.
-
-        We default use_slip132_version_byte to unamiguously communicate the network to Specter-Desktop.
         """
         # Check that we're using the root HDPrivateKey
         if self.depth != 0:

--- a/buidl/test/test_hd.py
+++ b/buidl/test/test_hd.py
@@ -546,20 +546,20 @@ class HDTest(TestCase):
         # mainnet
         hdpriv_obj = HDPrivateKey.from_mnemonic(seed_phrase)
         want = "[5436d724/48h/0h/0h/2h]Zpub74fkz9VnCkwXHqheLbKfBEPKPfnFg3S1Ecn7Jx4HgBWwD1FS5VLMtFYNqLmFBVifGuXKz2nirv647gFYCinhBSdBqrrh5vq8ok8m2eaRAt7"
-        self.assertEqual(hdpriv_obj.generate_p2wsh_key_record(), want)
-        want = "[5436d724/48h/0h/0h/2h]xpub6E79FaRWLSJCAgA2jDHRvyrWKwT6aSmR685zptzyYPvmUd44omcxZ1NAzDtbdFBvEADjcVbV4NzTDwQeU6oiSV9KGiMSWhjANZjbfUHkm3Y"
         self.assertEqual(
-            hdpriv_obj.generate_p2wsh_key_record(use_slip132_version_byte=False), want
+            hdpriv_obj.generate_p2wsh_key_record(use_slip132_version_byte=True), want
         )
+        want = "[5436d724/48h/0h/0h/2h]xpub6E79FaRWLSJCAgA2jDHRvyrWKwT6aSmR685zptzyYPvmUd44omcxZ1NAzDtbdFBvEADjcVbV4NzTDwQeU6oiSV9KGiMSWhjANZjbfUHkm3Y"
+        self.assertEqual(hdpriv_obj.generate_p2wsh_key_record(), want)
 
         # testnet
         hdpriv_obj = HDPrivateKey.from_mnemonic(seed_phrase, testnet=True)
         want = "[5436d724/48h/1h/0h/2h]Vpub5ncJ4gVToMcTWjG4shBZHeeCUXhX5r86W9cwggqw1m6aojbrHxr9yJFsoXaiXrBfAzV3TaVyxCB6EYUW21SVayfcAhiVc9XRJS1WL4Gh9td"
-        self.assertEqual(hdpriv_obj.generate_p2wsh_key_record(), want)
-        want = "[5436d724/48h/1h/0h/2h]tpubDFkN51vYF36W4Yfn3wGv5fpmRo3ok7vZZjc1gmRJjumq33L776e6GkP4HGdCVjDqYiBahXCrXQKja8aUZ2xovQNS8WkF46MdY7TLHJLYD7H"
         self.assertEqual(
-            hdpriv_obj.generate_p2wsh_key_record(use_slip132_version_byte=False), want
+            hdpriv_obj.generate_p2wsh_key_record(use_slip132_version_byte=True), want
         )
+        want = "[5436d724/48h/1h/0h/2h]tpubDFkN51vYF36W4Yfn3wGv5fpmRo3ok7vZZjc1gmRJjumq33L776e6GkP4HGdCVjDqYiBahXCrXQKja8aUZ2xovQNS8WkF46MdY7TLHJLYD7H"
+        self.assertEqual(hdpriv_obj.generate_p2wsh_key_record(), want)
 
 
 class BIP32PathsTest(TestCase):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="buidl",
-    version="0.2.19",
+    version="0.2.20",
     author="Example Author",
     author_email="author@example.com",
     description="An easy-to-use and fully featured bitcoin library written in pure python (no dependencies).",


### PR DESCRIPTION
I found a way to use specter-desktop without slip132 version bytes, so I'm making them no longer the default. Good riddance!