### PR TITLE
less ambiguous method names for base58 decoding

### DIFF
--- a/buidl/helper.py
+++ b/buidl/helper.py
@@ -153,7 +153,7 @@ def raw_decode_base58(s):
     return combined[:-4]
 
 
-def decode_base58(s):
+def decode_base58_addr(s):
     return raw_decode_base58(s)[1:]
 
 

--- a/buidl/test/test_helper.py
+++ b/buidl/test/test_helper.py
@@ -6,7 +6,7 @@ from buidl.helper import (
     bit_field_to_bytes,
     bytes_to_bit_field,
     bytes_to_str,
-    decode_base58,
+    decode_base58_addr,
     encode_base58_checksum,
     decode_golomb,
     encode_golomb,
@@ -54,13 +54,13 @@ class HelperTest(TestCase):
 
     def test_base58(self):
         addr = "mnrVtF8DWjMu839VW3rBfgYaAfKk8983Xf"
-        h160 = decode_base58(addr).hex()
+        h160 = decode_base58_addr(addr).hex()
         want = "507b27411ccf7f16f10297de6cef3f291623eddf"
         self.assertEqual(h160, want)
         got = encode_base58_checksum(b"\x6f" + bytes.fromhex(h160))
         self.assertEqual(got, addr)
         addr = "1111111111111111111114oLvT2"
-        h160 = decode_base58(addr).hex()
+        h160 = decode_base58_addr(addr).hex()
         want = "0000000000000000000000000000000000000000"
         self.assertEqual(h160, want)
         got = encode_base58_checksum(b"\x00" + bytes.fromhex(h160))

--- a/buidl/test/test_network.py
+++ b/buidl/test/test_network.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from io import BytesIO
 
 from buidl.block import Block
-from buidl.helper import decode_base58, decode_gcs
+from buidl.helper import decode_base58_addr, decode_gcs
 from buidl.network import (
     BASIC_FILTER_TYPE,
     CFCheckPointMessage,
@@ -107,7 +107,7 @@ if False:
             from buidl.bloomfilter import BloomFilter
 
             bf = BloomFilter(30, 5, 90210)
-            h160 = decode_base58("mseRGXB89UTFVkWJhTRTzzZ9Ujj4ZPbGK5")
+            h160 = decode_base58_addr("mseRGXB89UTFVkWJhTRTzzZ9Ujj4ZPbGK5")
             bf.add(h160)
             node = SimpleNode("tbtc.programmingblockchain.com", testnet=True)
             node.handshake()

--- a/buidl/test/test_script.py
+++ b/buidl/test/test_script.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from io import BytesIO
 
-from buidl.helper import decode_base58
+from buidl.helper import decode_base58_addr
 from buidl.script import (
     P2PKHScriptPubKey,
     P2SHScriptPubKey,
@@ -39,7 +39,7 @@ class ScriptTest(TestCase):
 class P2PKHScriptPubKeyTest(TestCase):
     def test_address(self):
         address_1 = "1BenRpVUFK65JFWcQSuHnJKzc4M8ZP8Eqa"
-        h160 = decode_base58(address_1)
+        h160 = decode_base58_addr(address_1)
         p2pkh_script_pubkey = P2PKHScriptPubKey(h160)
         self.assertEqual(p2pkh_script_pubkey.address(), address_1)
         address_2 = "mrAjisaT4LXL5MzE81sfcDYKU3wqWSvf9q"
@@ -49,7 +49,7 @@ class P2PKHScriptPubKeyTest(TestCase):
 class P2SHScriptPubKeyTest(TestCase):
     def test_address(self):
         address_1 = "3CLoMMyuoDQTPRD3XYZtCvgvkadrAdvdXh"
-        h160 = decode_base58(address_1)
+        h160 = decode_base58_addr(address_1)
         p2sh_script_pubkey = P2SHScriptPubKey(h160)
         self.assertEqual(p2sh_script_pubkey.address(), address_1)
         address_2 = "2N3u1R6uwQfuobCqbCgBkpsgBxvr1tZpe7B"

--- a/buidl/test/test_tx.py
+++ b/buidl/test/test_tx.py
@@ -2,7 +2,7 @@ from os.path import dirname, realpath, sep
 from unittest import TestCase
 
 from buidl.ecc import PrivateKey, Signature
-from buidl.helper import decode_base58
+from buidl.helper import decode_base58_addr
 from buidl.script import P2PKHScriptPubKey, RedeemScript, WitnessScript
 from buidl.tx import Tx, TxIn, TxOut, TxFetcher
 
@@ -155,11 +155,11 @@ class TxTest(TestCase):
         )
         tx_ins.append(TxIn(prev_tx, 0))
         tx_outs = []
-        h160 = decode_base58("mzx5YhAH9kNHtcN481u6WkjeHjYtVeKVh2")
+        h160 = decode_base58_addr("mzx5YhAH9kNHtcN481u6WkjeHjYtVeKVh2")
         tx_outs.append(
             TxOut(amount=int(0.99 * 100000000), script_pubkey=P2PKHScriptPubKey(h160))
         )
-        h160 = decode_base58("mnrVtF8DWjMu839VW3rBfgYaAfKk8983Xf")
+        h160 = decode_base58_addr("mnrVtF8DWjMu839VW3rBfgYaAfKk8983Xf")
         tx_outs.append(
             TxOut(amount=int(0.1 * 100000000), script_pubkey=P2PKHScriptPubKey(h160))
         )
@@ -175,7 +175,7 @@ class TxTest(TestCase):
         fee = 500
         tx_in = TxIn(prev_tx, prev_index)
         amount = tx_in.value(testnet=True) - fee
-        h160 = decode_base58("mqYz6JpuKukHzPg94y4XNDdPCEJrNkLQcv")
+        h160 = decode_base58_addr("mqYz6JpuKukHzPg94y4XNDdPCEJrNkLQcv")
         tx_out = TxOut(amount=amount, script_pubkey=P2PKHScriptPubKey(h160))
         t = Tx(1, [tx_in], [tx_out], 0, testnet=True, segwit=True)
         self.assertTrue(t.sign_input(0, private_key))
@@ -192,7 +192,7 @@ class TxTest(TestCase):
         fee = 500
         tx_in = TxIn(prev_tx, prev_index)
         amount = tx_in.value(testnet=True) - fee
-        h160 = decode_base58("mqYz6JpuKukHzPg94y4XNDdPCEJrNkLQcv")
+        h160 = decode_base58_addr("mqYz6JpuKukHzPg94y4XNDdPCEJrNkLQcv")
         tx_out = TxOut(amount=amount, script_pubkey=P2PKHScriptPubKey(h160))
         t = Tx(1, [tx_in], [tx_out], 0, testnet=True, segwit=True)
         self.assertTrue(t.sign_input(0, private_key, redeem_script=redeem_script))
@@ -207,11 +207,11 @@ class TxTest(TestCase):
         )
         tx_ins.append(TxIn(prev_tx, 0))
         tx_outs = []
-        h160 = decode_base58("mzx5YhAH9kNHtcN481u6WkjeHjYtVeKVh2")
+        h160 = decode_base58_addr("mzx5YhAH9kNHtcN481u6WkjeHjYtVeKVh2")
         tx_outs.append(
             TxOut(amount=int(0.99 * 100000000), script_pubkey=P2PKHScriptPubKey(h160))
         )
-        h160 = decode_base58("mnrVtF8DWjMu839VW3rBfgYaAfKk8983Xf")
+        h160 = decode_base58_addr("mnrVtF8DWjMu839VW3rBfgYaAfKk8983Xf")
         tx_outs.append(
             TxOut(amount=int(0.1 * 100000000), script_pubkey=P2PKHScriptPubKey(h160))
         )
@@ -231,7 +231,7 @@ class TxTest(TestCase):
         fee = 500
         tx_in = TxIn(prev_tx, prev_index)
         amount = tx_in.value(testnet=True) - fee
-        h160 = decode_base58("mqYz6JpuKukHzPg94y4XNDdPCEJrNkLQcv")
+        h160 = decode_base58_addr("mqYz6JpuKukHzPg94y4XNDdPCEJrNkLQcv")
         tx_out = TxOut(amount=amount, script_pubkey=P2PKHScriptPubKey(h160))
         t = Tx(1, [tx_in], [tx_out], 0, testnet=True, segwit=True)
         sig1 = t.get_sig_legacy(0, private_key1, redeem_script=redeem_script)
@@ -269,7 +269,7 @@ class TxTest(TestCase):
         fee = 500
         tx_in = TxIn(prev_tx, prev_index)
         amount = tx_in.value(testnet=True) - fee
-        h160 = decode_base58("mqYz6JpuKukHzPg94y4XNDdPCEJrNkLQcv")
+        h160 = decode_base58_addr("mqYz6JpuKukHzPg94y4XNDdPCEJrNkLQcv")
         tx_out = TxOut(amount=amount, script_pubkey=P2PKHScriptPubKey(h160))
         t = Tx(1, [tx_in], [tx_out], 0, testnet=True, segwit=True)
         sig1 = t.get_sig_segwit(0, private_key1, witness_script=witness_script)
@@ -307,7 +307,7 @@ class TxTest(TestCase):
         fee = 500
         tx_in = TxIn(prev_tx, prev_index)
         amount = tx_in.value(testnet=True) - fee
-        h160 = decode_base58("mqYz6JpuKukHzPg94y4XNDdPCEJrNkLQcv")
+        h160 = decode_base58_addr("mqYz6JpuKukHzPg94y4XNDdPCEJrNkLQcv")
         tx_out = TxOut(amount=amount, script_pubkey=P2PKHScriptPubKey(h160))
         t = Tx(1, [tx_in], [tx_out], 0, testnet=True, segwit=True)
         sig1 = t.get_sig_segwit(0, private_key1, witness_script=witness_script)

--- a/buidl/tx.py
+++ b/buidl/tx.py
@@ -6,7 +6,7 @@ import json
 
 from buidl.helper import (
     big_endian_to_int,
-    decode_base58,
+    decode_base58_addr,
     hash256,
     encode_varint,
     int_to_byte,
@@ -548,7 +548,7 @@ class Tx:
 
     def find_utxos(self, address):
         """Returns transaction outputs that matches the address"""
-        h160 = decode_base58(address)
+        h160 = decode_base58_addr(address)
         # utxos are a list of tuples: (hash, index, amount)
         utxos = []
         for index, tx_out in enumerate(self.tx_outs):


### PR DESCRIPTION
I got this complaint from a buidl user:

> "decode_base58 looks like a generic base58 function, but really its specialized for decoding addresses"