### PR TITLE
Fixes #77 and also adds flag for skipping slow tests

### DIFF
--- a/buidl/test/test_network.py
+++ b/buidl/test/test_network.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
+import unittest  # for skipunless
 
 from io import BytesIO
+from os import getenv
 
 from buidl.block import Block
 from buidl.helper import decode_base58, decode_gcs
@@ -94,6 +96,10 @@ class GetDataMessageTest(TestCase):
         self.assertEqual(get_data.serialize().hex(), hex_msg)
 
 
+@unittest.skipUnless(
+    getenv("INCLUDE_NETWORK_TESTS"),
+    reason="Requires network connection, so may not be unreliable",
+)
 class SimpleNodeTest(TestCase):
     def test_handshake(self):
         node = SimpleNode("testnet.programmingbitcoin.com", network="testnet")

--- a/test_multiwallet.py
+++ b/test_multiwallet.py
@@ -1,8 +1,13 @@
 import unittest
-
 import pexpect
 
+from os import getenv
 
+
+@unittest.skipIf(
+    getenv("SKIP_SLOW_TESTS"),
+    reason="This test takes a while",
+)
 class MultiwalletTest(unittest.TestCase):
     def expect(self, text):
         """

--- a/test_singlesweep.py
+++ b/test_singlesweep.py
@@ -2,9 +2,15 @@ import unittest
 
 import pexpect
 
+from os import getenv
+
 from buidl import PrivateKey
 
 
+@unittest.skipIf(
+    getenv("SKIP_SLOW_TESTS"),
+    reason="This test takes a while",
+)
 class SinglesweepTest(unittest.TestCase):
     def expect(self, text):
         """


### PR DESCRIPTION
I like these new features `INCLUDE_NETWORK_TESTS` and `SKIP_SLOW_TESTS`!

```
mflaxman@Michaels-MacBook-Pro:~/workspace/buidl-python$ INCLUDE_NETWORK_TESTS=1 pytest .
========================================================= test session starts ==========================================================
platform darwin -- Python 3.9.0, pytest-6.1.1, py-1.10.0, pluggy-0.13.1
rootdir: /Users/mflaxman/workspace/buidl-python
collected 203 items                                                                                                                    

test_multiwallet.py ........                                                                                                     [  3%]
test_singlesweep.py ....                                                                                                         [  5%]
buidl/test/test_bcur.py .........                                                                                                [ 10%]
buidl/test/test_bech32.py .                                                                                                      [ 10%]
buidl/test/test_blinding.py ........                                                                                             [ 14%]
buidl/test/test_block.py ..........                                                                                              [ 19%]
buidl/test/test_bloomfilter.py ..                                                                                                [ 20%]
buidl/test/test_descriptor.py ............                                                                                       [ 26%]
buidl/test/test_ecc.py ..........                                                                                                [ 31%]
buidl/test/test_hd.py ...................                                                                                        [ 40%]
buidl/test/test_helper.py .............                                                                                          [ 47%]
buidl/test/test_merkleblock.py .....                                                                                             [ 49%]
buidl/test/test_mnemonic.py ..                                                                                                   [ 50%]
buidl/test/test_network.py .............                                                                                         [ 57%]
buidl/test/test_op.py ...                                                                                                        [ 58%]
buidl/test/test_pecc.py ..............                                                                                           [ 65%]
buidl/test/test_psbt.py ................................                                                                         [ 81%]
buidl/test/test_script.py ........                                                                                               [ 85%]
buidl/test/test_shamir.py ....                                                                                                   [ 87%]
buidl/test/test_tx.py ..........................                                                                                 [100%]

========================================================= 203 passed in 13.87s =========================================================



mflaxman@Michaels-MacBook-Pro:~/workspace/buidl-python$ SKIP_SLOW_TESTS=1 pytest .
========================================================= test session starts ==========================================================
platform darwin -- Python 3.9.0, pytest-6.1.1, py-1.10.0, pluggy-0.13.1
rootdir: /Users/mflaxman/workspace/buidl-python
collected 203 items                                                                                                                    

test_multiwallet.py ssssssss                                                                                                     [  3%]
test_singlesweep.py ssss                                                                                                         [  5%]
buidl/test/test_bcur.py .........                                                                                                [ 10%]
buidl/test/test_bech32.py .                                                                                                      [ 10%]
buidl/test/test_blinding.py ........                                                                                             [ 14%]
buidl/test/test_block.py ..........                                                                                              [ 19%]
buidl/test/test_bloomfilter.py ..                                                                                                [ 20%]
buidl/test/test_descriptor.py ............                                                                                       [ 26%]
buidl/test/test_ecc.py ..........                                                                                                [ 31%]
buidl/test/test_hd.py ...................                                                                                        [ 40%]
buidl/test/test_helper.py .............                                                                                          [ 47%]
buidl/test/test_merkleblock.py .....                                                                                             [ 49%]
buidl/test/test_mnemonic.py ..                                                                                                   [ 50%]
buidl/test/test_network.py ......sss....                                                                                         [ 57%]
buidl/test/test_op.py ...                                                                                                        [ 58%]
buidl/test/test_pecc.py ..............                                                                                           [ 65%]
buidl/test/test_psbt.py ................................                                                                         [ 81%]
buidl/test/test_script.py ........                                                                                               [ 85%]
buidl/test/test_shamir.py ....                                                                                                   [ 87%]
buidl/test/test_tx.py ..........................                                                                                 [100%]

=================================================== 188 passed, 15 skipped in 3.66s ====================================================




mflaxman@Michaels-MacBook-Pro:~/workspace/buidl-python$ pytest .
========================================================= test session starts ==========================================================
platform darwin -- Python 3.9.0, pytest-6.1.1, py-1.10.0, pluggy-0.13.1
rootdir: /Users/mflaxman/workspace/buidl-python
collected 203 items                                                                                                                    

test_multiwallet.py ........                                                                                                     [  3%]
test_singlesweep.py ....                                                                                                         [  5%]
buidl/test/test_bcur.py .........                                                                                                [ 10%]
buidl/test/test_bech32.py .                                                                                                      [ 10%]
buidl/test/test_blinding.py ........                                                                                             [ 14%]
buidl/test/test_block.py ..........                                                                                              [ 19%]
buidl/test/test_bloomfilter.py ..                                                                                                [ 20%]
buidl/test/test_descriptor.py ............                                                                                       [ 26%]
buidl/test/test_ecc.py ..........                                                                                                [ 31%]
buidl/test/test_hd.py ...................                                                                                        [ 40%]
buidl/test/test_helper.py .............                                                                                          [ 47%]
buidl/test/test_merkleblock.py .....                                                                                             [ 49%]
buidl/test/test_mnemonic.py ..                                                                                                   [ 50%]
buidl/test/test_network.py ......sss....                                                                                         [ 57%]
buidl/test/test_op.py ...                                                                                                        [ 58%]
buidl/test/test_pecc.py ..............                                                                                           [ 65%]
buidl/test/test_psbt.py ................................                                                                         [ 81%]
buidl/test/test_script.py ........                                                                                               [ 85%]
buidl/test/test_shamir.py ....                                                                                                   [ 87%]
buidl/test/test_tx.py ..........................                                                                                 [100%]

=================================================== 200 passed, 3 skipped in 13.02s ====================================================
```