### PR TITLE
p2sh psbt convenience methods

### DIFF
--- a/buidl/__init__.py
+++ b/buidl/__init__.py
@@ -14,6 +14,7 @@ from .network import *
 from .op import *
 from .pbkdf2 import *
 from .psbt import *
+from .psbt_helper import *
 from .script import *
 from .shamir import *
 from .tx import *

--- a/buidl/hd.py
+++ b/buidl/hd.py
@@ -708,3 +708,21 @@ def ltrim_path(bip32_path, depth):
 
     to_return = path.split("/")[depth + 1 :]
     return "m/" + "/".join(to_return)
+
+
+def get_unhardened_child_path(base_path, root_path):
+    """
+    Return the difference between the base_path and root_path.
+
+    Return None if there is no child_path (or it require hardened derivation).
+    """
+    if not is_valid_bip32_path(root_path):
+        raise ValueError(f"Invalid bip32_path: {root_path}")
+
+    base_path = base_path.strip().lower().replace("h", "'")
+    root_path = root_path.strip().lower().replace("h", "'")
+
+    if root_path.startswith(base_path):
+        child_path = root_path[len(base_path) :]
+        if "'" not in child_path:
+            return f"m{child_path}"

--- a/buidl/psbt.py
+++ b/buidl/psbt.py
@@ -190,19 +190,21 @@ class NamedHDPublicKey(HDPublicKey):
         return hd_key
 
     @classmethod
-    def from_hd_pub(cls, child_hd_pub, fingerprint_hex, full_path):
+    def from_hd_pub(cls, child_hd_pub, fingerprint_hex, root_path):
         hd_key = child_hd_pub
         hd_key.__class__ = cls
         hd_key.add_raw_path_data(
-            bytes.fromhex(fingerprint_hex) + serialize_binary_path(full_path)
+            bytes.fromhex(fingerprint_hex) + serialize_binary_path(root_path)
         )
         return hd_key
 
     @classmethod
-    def from_hd_priv(cls, hd_priv, path):
-        hd_key = hd_priv.traverse(path).pub
+    def from_hd_priv(cls, hd_priv, root_path):
+        hd_key = hd_priv.traverse(root_path).pub
         hd_key.__class__ = cls
-        hd_key.add_raw_path_data(hd_priv.fingerprint() + serialize_binary_path(path))
+        hd_key.add_raw_path_data(
+            hd_priv.fingerprint() + serialize_binary_path(root_path)
+        )
         return hd_key
 
     def serialize(self):

--- a/buidl/psbt.py
+++ b/buidl/psbt.py
@@ -196,11 +196,11 @@ class NamedHDPublicKey(HDPublicKey):
         return hd_key
 
     @classmethod
-    def from_hd_pub(cls, child_hd_pub, fingerprint_hex, root_path):
+    def from_hd_pub(cls, child_hd_pub, xfp_hex, root_path):
         hd_key = child_hd_pub
         hd_key.__class__ = cls
         hd_key.add_raw_path_data(
-            bytes.fromhex(fingerprint_hex) + serialize_binary_path(root_path)
+            bytes.fromhex(xfp_hex) + serialize_binary_path(root_path)
         )
         return hd_key
 
@@ -209,7 +209,7 @@ class NamedHDPublicKey(HDPublicKey):
         child_hd_pub = root_hd_priv.traverse(root_path).pub
         return cls.from_hd_pub(
             child_hd_pub=child_hd_pub,
-            fingerprint_hex=root_hd_priv.fingerprint().hex(),
+            xfp_hex=root_hd_priv.fingerprint().hex(),
             root_path=root_path,
         )
 

--- a/buidl/psbt.py
+++ b/buidl/psbt.py
@@ -194,7 +194,7 @@ class NamedHDPublicKey(HDPublicKey):
         hd_key = child_hd_pub
         hd_key.__class__ = cls
         hd_key.add_raw_path_data(
-            bytes.fromhex(fingerprint_hex) + serialize_binary_path(path)
+            bytes.fromhex(fingerprint_hex) + serialize_binary_path(full_path)
         )
         return hd_key
 

--- a/buidl/psbt.py
+++ b/buidl/psbt.py
@@ -205,13 +205,13 @@ class NamedHDPublicKey(HDPublicKey):
         return hd_key
 
     @classmethod
-    def from_hd_priv(cls, hd_priv, root_path):
-        hd_key = hd_priv.traverse(root_path).pub
-        hd_key.__class__ = cls
-        hd_key.add_raw_path_data(
-            hd_priv.fingerprint() + serialize_binary_path(root_path)
+    def from_hd_priv(cls, root_hd_priv, root_path):
+        child_hd_pub = root_hd_priv.traverse(root_path).pub
+        return cls.from_hd_pub(
+            child_hd_pub=child_hd_pub,
+            fingerprint_hex=root_hd_priv.fingerprint().hex(),
+            root_path=root_path,
         )
-        return hd_key
 
     def serialize(self):
         return serialize_key_value(

--- a/buidl/psbt.py
+++ b/buidl/psbt.py
@@ -190,6 +190,15 @@ class NamedHDPublicKey(HDPublicKey):
         return hd_key
 
     @classmethod
+    def from_hd_pub(cls, child_hd_pub, fingerprint_hex, full_path):
+        hd_key = child_hd_pub
+        hd_key.__class__ = cls
+        hd_key.add_raw_path_data(
+            bytes.fromhex(fingerprint_hex) + serialize_binary_path(path)
+        )
+        return hd_key
+
+    @classmethod
     def from_hd_priv(cls, hd_priv, path):
         hd_key = hd_priv.traverse(path).pub
         hd_key.__class__ = cls

--- a/buidl/psbt_helper.py
+++ b/buidl/psbt_helper.py
@@ -90,7 +90,7 @@ def create_ps2sh_multisig_psbt(
             # Enhance the PSBT
             named_hd_pubkey_obj = NamedHDPublicKey.from_hd_pub(
                 child_hd_pub=child_hd_pubkey,
-                fingerprint_hex=xfp_hex,
+                xfp_hex=xfp_hex,
                 root_path=root_path,
             )
             pubkey_lookup[named_hd_pubkey_obj.sec()] = named_hd_pubkey_obj
@@ -151,7 +151,7 @@ def create_ps2sh_multisig_psbt(
                 # Enhance the PSBT
                 named_hd_pubkey_obj = NamedHDPublicKey.from_hd_pub(
                     child_hd_pub=child_hd_pubkey,
-                    fingerprint_hex=xfp_hex,
+                    xfp_hex=xfp_hex,
                     root_path=root_path,
                 )
                 pubkey_lookup[named_hd_pubkey_obj.sec()] = named_hd_pubkey_obj

--- a/buidl/psbt_helper.py
+++ b/buidl/psbt_helper.py
@@ -7,7 +7,7 @@ from buidl.script import RedeemScript, address_to_script_pubkey
 
 def create_ps2sh_multisig_psbt(
     quorum_m,
-    xpub_dict_list,
+    xpubs_dict,
     inputs_dict_list,
     outputs_dict_list,
     fee_sats,
@@ -23,14 +23,14 @@ def create_ps2sh_multisig_psbt(
     # This at the child pubkey lookup that each input will traverse off of
     xfp_dict = {}
     network = None
-    for cnt, xpub_dict in enumerate(xpub_dict_list):
+    for xfp_hex, xpub_values in xpubs_dict.items():
 
-        hd_pubkey_obj = HDPublicKey.parse(xpub_dict["xpub_hex"])
+        hd_pubkey_obj = HDPublicKey.parse(xpub_values["xpub_hex"])
 
         # We will use this dict on each input below
-        xfp_dict[xpub_dict["fingerprint_hex"]] = {
+        xfp_dict[xfp_hex] = {
             "xpub_obj": hd_pubkey_obj,
-            "base_path": xpub_dict["base_path"],
+            "base_path": xpub_values["base_path"],
         }
 
         if network is None:

--- a/buidl/psbt_helper.py
+++ b/buidl/psbt_helper.py
@@ -39,7 +39,7 @@ def create_ps2sh_multisig_psbt(
         else:
             # Confirm it hasn't changed
             if network != hd_pubkey_obj.network:
-                raise MixedNetwork(f"Mixed networks in xpubs: {xpub_dict_list}")
+                raise MixedNetwork(f"Mixed networks in xpubs: {xpubs_dict}")
 
     tx_lookup, pubkey_lookup, redeem_lookup = {}, {}, {}
 
@@ -64,7 +64,7 @@ def create_ps2sh_multisig_psbt(
         for xfp_hex, bip32_child_path in input_dict["path_dict"].items():
             if xfp_hex not in xfp_dict:
                 raise ValueError(
-                    f"xfp_hex {xfp_hex} from input #{cnt} not supplied in xpub_dict_list:  {xpub_dict_list}"
+                    f"xfp_hex {xfp_hex} from input #{cnt} not supplied in xpubs_dict:  {xpubs_dict}"
                 )
 
             child_hd_pubkey = xfp_dict[xfp_hex]["xpub_obj"].traverse(bip32_child_path)

--- a/buidl/psbt_helper.py
+++ b/buidl/psbt_helper.py
@@ -6,7 +6,6 @@ from buidl.script import RedeemScript, address_to_script_pubkey
 
 
 def create_ps2sh_multisig_psbt(
-    quorum_m,
     xpubs_dict,
     input_dicts,
     output_dicts,
@@ -89,7 +88,7 @@ def create_ps2sh_multisig_psbt(
 
         # This allows us to spend from a redeem script with pubkeys out of order
         redeem_script = RedeemScript.create_p2sh_multisig_unsorted(
-            quorum_m=quorum_m,
+            quorum_m=input_dict["quorum_m"],
             pubkey_hex_list=input_pubkey_hexes,
             target_address=utxo.script_pubkey.address(network=network),
             network=network,
@@ -146,7 +145,7 @@ def create_ps2sh_multisig_psbt(
                 pubkey_lookup[named_hd_pubkey_obj.sec()] = named_hd_pubkey_obj
 
             redeem_script = RedeemScript.create_p2sh_multisig(
-                quorum_m=quorum_m,
+                quorum_m=output_dict["quorum_m"],
                 # TODO: allow for trying multiple combinations
                 pubkey_hex_list=output_pubkey_hexes,
                 # Electrum sorts lexicographically:

--- a/buidl/psbt_helper.py
+++ b/buidl/psbt_helper.py
@@ -104,12 +104,12 @@ def create_p2sh_multisig_psbt(
             )
         total_input_sats += utxo.amount
 
-        # This allows us to spend from a redeem script with pubkeys out of order
-        redeem_script = RedeemScript.create_p2sh_multisig_unsorted(
+        redeem_script = RedeemScript.create_p2sh_multisig(
             quorum_m=input_dict["quorum_m"],
-            pubkey_hexes=input_pubkey_hexes,
-            target_address=utxo.script_pubkey.address(network=network),
-            network=network,
+            # assumes you want to sort pubkeys. TODO: allow for over-ride method?
+            pubkey_hexes=sorted(input_pubkey_hexes),
+            expected_addr=utxo.script_pubkey.address(network=network),
+            expected_addr_network=network,
         )
 
         # Confirm address matches previous ouput
@@ -159,7 +159,7 @@ def create_p2sh_multisig_psbt(
             redeem_script = RedeemScript.create_p2sh_multisig(
                 quorum_m=output_dict["quorum_m"],
                 pubkey_hexes=output_pubkey_hexes,
-                # We intentionally only allow change addresses (output addresses) to be lexicographically sorted
+                # We intentionally only allow change addresses to be lexicographically sorted
                 sort_keys=True,
             )
             # Confirm address matches previous ouput

--- a/buidl/psbt_helper.py
+++ b/buidl/psbt_helper.py
@@ -14,7 +14,7 @@ def _append(mydict, key, val):
 
 def _get_child_hdpubkey(xpub_dicts, root_path):
     """
-    Iterate through a list of
+    Iterate through a list of xpub_dicts to find one that can traverse to the given root_path
     """
     for xpub_dict in xpub_dicts:
         child_path = get_unhardened_child_path(

--- a/buidl/psbt_helper.py
+++ b/buidl/psbt_helper.py
@@ -122,11 +122,11 @@ def create_ps2sh_multisig_psbt(
         if output_dict.get("path_dict"):
             # Confirm change
             output_pubkey_hexes = []
-            for xfp_hex, bip32_child_path in input_dict["path_dict"].items():
+            for xfp_hex, bip32_child_path in output_dict["path_dict"].items():
 
                 if xfp_hex not in xfp_dict:
                     raise ValueError(
-                        f"xfp_hex {xfp_hex} from input #{cnt} not supplied in xpubs_dict:  {xpubs_dict}"
+                        f"xfp_hex {xfp_hex} from output #{cnt} not supplied in xpubs_dict:  {xpubs_dict}"
                     )
 
                 child_hd_pubkey = xfp_dict[xfp_hex]["xpub_obj"].traverse(

--- a/buidl/psbt_helper.py
+++ b/buidl/psbt_helper.py
@@ -8,8 +8,8 @@ from buidl.script import RedeemScript, address_to_script_pubkey
 def create_ps2sh_multisig_psbt(
     quorum_m,
     xpubs_dict,
-    inputs_dict_list,
-    outputs_dict_list,
+    input_dicts,
+    output_dicts,
     fee_sats,
 ):
     """
@@ -42,7 +42,7 @@ def create_ps2sh_multisig_psbt(
     tx_lookup, pubkey_lookup, redeem_lookup = {}, {}, {}
 
     tx_ins = []
-    for cnt, input_dict in enumerate(inputs_dict_list):
+    for cnt, input_dict in enumerate(input_dicts):
         # This could get unwieldy for TXs with a large number of inputs, especially ones that were the result of large (batched) transactions
         # TODO: is there a way to only require the prev_hash/idx/ammount and not the full tx hex?
 
@@ -112,7 +112,7 @@ def create_ps2sh_multisig_psbt(
         redeem_lookup[redeem_script.hash160()] = redeem_script
 
     tx_outs = []
-    for output_dict in outputs_dict_list:
+    for output_dict in output_dicts:
         tx_out = TxOut(
             amount=output_dict["sats"],
             script_pubkey=address_to_script_pubkey(output_dict["address"]),

--- a/buidl/psbt_helper.py
+++ b/buidl/psbt_helper.py
@@ -23,7 +23,7 @@ def _get_child_hdpubkey(xpub_dict, root_path):
                 return xpub_obj.traverse(child_path)
 
 
-def create_ps2sh_multisig_psbt(
+def create_p2sh_multisig_psbt(
     xpubs_dict,
     input_dicts,
     output_dicts,

--- a/buidl/psbt_helper.py
+++ b/buidl/psbt_helper.py
@@ -115,7 +115,7 @@ def create_ps2sh_multisig_psbt(
         redeem_lookup[redeem_script.hash160()] = redeem_script
 
     tx_outs = []
-    for cnt, output_dict in enumerate(outputs_dict_list):
+    for output_dict in outputs_dict_list:
         tx_out = TxOut(
             amount=output_dict["sats"],
             script_pubkey=address_to_script_pubkey(output_dict["address"]),

--- a/buidl/psbt_helper.py
+++ b/buidl/psbt_helper.py
@@ -107,7 +107,7 @@ def create_ps2sh_multisig_psbt(
         # This allows us to spend from a redeem script with pubkeys out of order
         redeem_script = RedeemScript.create_p2sh_multisig_unsorted(
             quorum_m=input_dict["quorum_m"],
-            pubkey_hex_list=input_pubkey_hexes,
+            pubkey_hexes=input_pubkey_hexes,
             target_address=utxo.script_pubkey.address(network=network),
             network=network,
         )
@@ -158,7 +158,7 @@ def create_ps2sh_multisig_psbt(
 
             redeem_script = RedeemScript.create_p2sh_multisig(
                 quorum_m=output_dict["quorum_m"],
-                pubkey_hex_list=output_pubkey_hexes,
+                pubkey_hexes=output_pubkey_hexes,
                 # We intentionally only allow change addresses (output addresses) to be lexicographically sorted
                 sort_keys=True,
             )
@@ -174,7 +174,7 @@ def create_ps2sh_multisig_psbt(
         tx_outs=tx_outs,
         locktime=0,
         network=network,
-        segwit=True,
+        segwit=False,
     )
 
     # Safety check to try and prevent footgun

--- a/buidl/script.py
+++ b/buidl/script.py
@@ -1,3 +1,4 @@
+from itertools import permutations
 from io import BytesIO
 
 from buidl.bech32 import decode_bech32, encode_bech32_checksum
@@ -398,6 +399,30 @@ class RedeemScript(Script):
         commands.append(174)  # OP_CHECKMULTISIG
 
         return cls(commands)
+
+    @classmethod
+    def create_p2sh_multisig_unsorted(
+        cls, quorum_m, pubkey_hex_list, target_address, network="main"
+    ):
+        """
+        Helper method to create a p2sh that orders pubkeys to get a target_address.
+
+        DO NOT USE THIS METHOD IF YOU DON'T UNDERSTAND WHAT IT'S DOING.
+        THIS SHOULD ONLY BE USED FOR SPENDING OUT OF A LEGACY ADDRESS.
+        DO NOT SEND NEW FUNDS TO AN ADDRESS GENERATED USING THIS METHOD.
+        Instead, use the regular create_p2sh_multisig method (with sort_keys=True) to generate a modern address.
+        """
+        for permutation in permutations(pubkey_hex_list):
+            result = cls.create_p2sh_multisig(
+                quorum_m=quorum_m, pubkey_hex_list=permutation, sort_keys=False
+            )
+            if result.address(network) == target_address:
+                return result
+
+        # We didn't get a match
+        raise ValueError(
+            f"Could not find a combination of pubkeys the generated address {target_address}"
+        )
 
     def get_quorum(self):
         """

--- a/buidl/script.py
+++ b/buidl/script.py
@@ -396,8 +396,6 @@ class RedeemScript(Script):
 
         if sort_keys:
             pubkey_hexes = sorted(pubkey_hexes)
-        else:
-            pubkey_hexes = pubkey_hexes
 
         for pubkey_hex in pubkey_hexes:
             # we want these in binary (not hex)

--- a/buidl/script.py
+++ b/buidl/script.py
@@ -353,6 +353,9 @@ class P2SHScriptPubKey(ScriptPubKey):
 class RedeemScript(Script):
     """Subclass that represents a RedeemScript for p2sh"""
 
+    def is_p2sh_multisig(self):
+        return self.commands[-1] == 174
+
     def hash160(self):
         """Returns the hash160 of the serialization of the RedeemScript"""
         return hash160(self.raw_serialize())
@@ -444,8 +447,8 @@ class RedeemScript(Script):
         """
         Return the m-of-n of this multisig, as in 2-of-3 or 3-of-5
         """
-        if self.commands[-1] != 174:
-            raise ValueError(f"Not OP_CHECKMULTISIG: {self}")
+        if not self.is_p2sh_multisig():
+            raise ValueError(f"Not p2sh multisig: {self}")
         quorum_m = op_code_to_number(self.commands[0])
         # 3 because quorum_m, OP_CHECKMULTISIG, and bitcoin off-by-one error
         quorum_n = len(self.commands) - 3
@@ -455,6 +458,8 @@ class RedeemScript(Script):
         """
         The pubkeys needed to sign this transaction, typically children derived from xpubs
         """
+        if not self.is_p2sh_multisig():
+            raise ValueError(f"Not p2sh multisig: {self}")
         return self.commands[1:-2]
 
 

--- a/buidl/script.py
+++ b/buidl/script.py
@@ -1,4 +1,3 @@
-from itertools import permutations
 from io import BytesIO
 
 from buidl.bech32 import decode_bech32, encode_bech32_checksum
@@ -418,30 +417,6 @@ class RedeemScript(Script):
                 )
 
         return to_return
-
-    @classmethod
-    def create_p2sh_multisig_unsorted(
-        cls, quorum_m, pubkey_hexes, target_address, network="main"
-    ):
-        """
-        Helper method to create a p2sh that orders pubkeys to get a target_address.
-
-        DO NOT USE THIS METHOD IF YOU DON'T UNDERSTAND WHAT IT'S DOING.
-        THIS SHOULD ONLY BE USED FOR SPENDING OUT OF A LEGACY ADDRESS.
-        DO NOT SEND NEW FUNDS TO AN ADDRESS GENERATED USING THIS METHOD.
-        Instead, use the regular create_p2sh_multisig method (with sort_keys=True) to generate a modern address.
-        """
-        for permutation in permutations(pubkey_hexes):
-            result = cls.create_p2sh_multisig(
-                quorum_m=quorum_m, pubkey_hexes=permutation, sort_keys=False
-            )
-            if result.address(network) == target_address:
-                return result
-
-        # We didn't get a match
-        raise ValueError(
-            f"Could not find a combination of pubkeys the generated address {target_address}"
-        )
 
     def get_quorum(self):
         """

--- a/buidl/script.py
+++ b/buidl/script.py
@@ -447,6 +447,7 @@ class RedeemScript(Script):
         if self.commands[-1] != 174:
             raise ValueError(f"Not OP_CHECKMULTISIG: {self}")
         quorum_m = op_code_to_number(self.commands[0])
+        # 3 because quorum_m, OP_CHECKMULTISIG, and bitcoin off-by-one error
         quorum_n = len(self.commands) - 3
         return quorum_m, quorum_n
 

--- a/buidl/script.py
+++ b/buidl/script.py
@@ -14,6 +14,7 @@ from buidl.helper import (
 )
 from buidl.op import (
     number_to_op_code,
+    op_code_to_number,
     op_equal,
     op_hash160,
     op_verify,
@@ -397,6 +398,22 @@ class RedeemScript(Script):
         commands.append(174)  # OP_CHECKMULTISIG
 
         return cls(commands)
+
+    def get_quorum(self):
+        """
+        Return the m-of-n of this multisig, as in 2-of-3 or 3-of-5
+        """
+        if self.commands[-1] != 174:
+            raise ValueError(f"Not OP_CHECKMULTISIG: {self}")
+        quorum_m = op_code_to_number(self.commands[0])
+        quorum_n = len(self.commands) - 3
+        return quorum_m, quorum_n
+
+    def signing_pubkeys(self):
+        """
+        The pubkeys needed to sign this transaction, typically children derived from xpubs
+        """
+        return self.commands[1:-2]
 
 
 class SegwitPubKey(ScriptPubKey):

--- a/buidl/test/test_hd.py
+++ b/buidl/test/test_hd.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from buidl.hd import (
     calc_num_valid_seedpicker_checksums,
     calc_valid_seedpicker_checksums,
+    get_unhardened_child_path,
     HDPublicKey,
     HDPrivateKey,
     is_valid_bip32_path,
@@ -668,3 +669,14 @@ class BIP32PathsTest(TestCase):
 
         with self.assertRaises(ValueError):
             ltrim_path("m/", 1)
+
+    def test_child_path_calc(self):
+        self.assertEqual(get_unhardened_child_path("m/45h/0", "m/45h/0/0/1"), "m/0/1")
+        self.assertEqual(get_unhardened_child_path("m/45h/0", "m/45h/0/0/1"), "m/0/1")
+        self.assertEqual(get_unhardened_child_path("m/45h/0", "m/45h/0"), "m")
+
+        # Hardened derivation after base (m/0h/1)
+        self.assertIsNone(get_unhardened_child_path("m/45h/0", "m/45h/0/0'/1"))
+
+        # Doesn't share a base
+        self.assertIsNone(get_unhardened_child_path("m/0/1", "m/45h/0/0"))

--- a/buidl/test/test_psbt.py
+++ b/buidl/test/test_psbt.py
@@ -466,8 +466,10 @@ class PSBTTest(TestCase):
         )
         pubkey_lookup = {}
         for i in range(6):
-            path = "m/0'/0'/{}'".format(i)
-            named_pubkey = NamedHDPublicKey.from_hd_priv(hd_priv, path)
+            root_path = "m/0'/0'/{}'".format(i)
+            named_pubkey = NamedHDPublicKey.from_hd_priv(
+                root_hd_priv=hd_priv, root_path=root_path
+            )
             pubkey_lookup[named_pubkey.sec()] = named_pubkey
             pubkey_lookup[named_pubkey.hash160()] = named_pubkey
         redeem_lookup = {}

--- a/buidl/test/test_psbt_helper.py
+++ b/buidl/test/test_psbt_helper.py
@@ -107,7 +107,7 @@ class P2SHTest(TestCase):
                     "base_path": "m/45h/0",
                 },
             },
-            "inputs_dict_list": [
+            "input_dicts": [
                 {
                     "path_dict": {
                         # xfp: child_path
@@ -122,7 +122,7 @@ class P2SHTest(TestCase):
                     },
                 },
             ],
-            "outputs_dict_list": [
+            "output_dicts": [
                 {
                     "sats": 999500,
                     "address": "mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
@@ -180,7 +180,7 @@ class P2SHTest(TestCase):
 
         # TODO fresh test with broadcast to blockchain
 
-        kwargs["outputs_dict_list"] = [
+        kwargs["output_dicts"] = [
             {
                 "sats": 999500,
                 "address": "2ND4qfpdHyeXJboAUkKZqJsyiKyXvHRKhbi",

--- a/buidl/test/test_psbt_helper.py
+++ b/buidl/test/test_psbt_helper.py
@@ -22,13 +22,13 @@ class P2SHTest(TestCase):
 
         # Validate the 0th receive address for m/45'/0
         expected_spending_addr = "2ND4qfpdHyeXJboAUkKZqJsyiKyXvHRKhbi"
-        pubkey_hex_list = [
+        pubkey_hexes = [
             hdpriv.traverse(root_path).pub.sec().hex() for hdpriv in hdprivs
         ]
 
         redeem_script_to_use = RedeemScript.create_p2sh_multisig(
             quorum_m=1,
-            pubkey_hex_list=pubkey_hex_list,
+            pubkey_hexes=pubkey_hexes,
             sort_keys=True,
         )
         self.assertEqual(
@@ -86,7 +86,7 @@ class P2SHTest(TestCase):
             "fee_sats": 213684,
         }
 
-        expected_unsigned_psbt_hex = "70736274ff01005801000000000101daa77c81a45d35ca2da4c6676043ee60f1ac9a9e350a4a78bb014d66a7d212440000000000ffffffff014c400f00000000001976a914344a0f48ca150ec2b903817660b9b68b13a6702688ac0000000000000100e002000000000101380bff9db676d159ad34849079c77e0d5c1df9c841b6a6640cba9bfc15077eea0100000000feffffff02008312000000000017a914d96bb9c5888f473dbd077d77009fb49ba2fda24287611c92a00100000017a9148722f07fbcf0fc506ea4ba9daa811d11396bbcfd870247304402202fe3c2f18e1486407bf0baabd2b3376102f0844a754d8e2fb8de71b39b3f76c702200c1fe8f7f9ef5165929ed51bf754edd7dd3e591921979cf5b891c841a1fd19d80121037c8fe1fa1ae4dfff522c532917c73c4884469e3b6a284e9a039ec612dca78eefd29c1e00010447512102139f7167f17da94d24df6fe2868cdb5edabd0cff83ab487c942ea2f07570d9f021023cb71c699990768c018df17a366c4eb74bde169f29e884261c10c973ec26ad3a52ae220602139f7167f17da94d24df6fe2868cdb5edabd0cff83ab487c942ea2f07570d9f014838f3ff92d0000800000000000000000000000002206023cb71c699990768c018df17a366c4eb74bde169f29e884261c10c973ec26ad3a14e0c595c52d0000800000000000000000000000000000"
+        expected_unsigned_psbt_b64 = "cHNidP8BAFUBAAAAAdqnfIGkXTXKLaTGZ2BD7mDxrJqeNQpKeLsBTWan0hJEAAAAAAD/////AUxADwAAAAAAGXapFDRKD0jKFQ7CuQOBdmC5tosTpnAmiKwAAAAAAAEA4AIAAAAAAQE4C/+dtnbRWa00hJB5x34NXB35yEG2pmQMupv8FQd+6gEAAAAA/v///wIAgxIAAAAAABepFNlrucWIj0c9vQd9dwCftJui/aJCh2EckqABAAAAF6kUhyLwf7zw/FBupLqdqoEdETlrvP2HAkcwRAIgL+PC8Y4UhkB78Lqr0rM3YQLwhEp1TY4vuN5xs5s/dscCIAwf6Pf571Flkp7VG/dU7dfdPlkZIZec9biRyEGh/RnYASEDfI/h+hrk3/9SLFMpF8c8SIRGnjtqKE6aA57GEtynju/SnB4AAQRHUSECE59xZ/F9qU0k32/ihozbXtq9DP+Dq0h8lC6i8HVw2fAhAjy3HGmZkHaMAY3xejZsTrdL3hafKeiEJhwQyXPsJq06Uq4iBgITn3Fn8X2pTSTfb+KGjNte2r0M/4OrSHyULqLwdXDZ8BSDjz/5LQAAgAAAAAAAAAAAAAAAACIGAjy3HGmZkHaMAY3xejZsTrdL3hafKeiEJhwQyXPsJq06FODFlcUtAACAAAAAAAAAAAAAAAAAAAA="
 
         tests = (
             # (seed_word repeated x12, signed_tx_hash_hex),
@@ -104,7 +104,7 @@ class P2SHTest(TestCase):
         # Now we prove we can sign this with either key
         for seed_word, signed_tx_hash_hex in tests:
             psbt_obj = create_ps2sh_multisig_psbt(**kwargs)
-            self.assertEqual(psbt_obj.serialize().hex(), expected_unsigned_psbt_hex)
+            self.assertEqual(psbt_obj.serialize_base64(), expected_unsigned_psbt_b64)
 
             hdpriv = HDPrivateKey.from_mnemonic(seed_word * 12, network="testnet")
 
@@ -191,8 +191,7 @@ class P2SHTest(TestCase):
             "fee_sats": 4000,
         }
 
-        # FIXME: this PSBT doesn't appear to parse!?
-        expected_unsigned_psbt_hex = "70736274ff01007501000000000101a294ff73bafec95f340b667c0f05b968bbab1a5b14ed54d2288518dec191bc3b0100000000ffffffff02e80300000000000017a9144e939ddfe567971692d19559f1f92d4fae5aa056878813000000000000160014ff9da567e62f30ea8654fa1d5fbd47bef8e3be130000000000000100df020000000001012c40a6810f7a670913d171e1f5b203ca01ed45ed3bf68b649850491eecb560080100000000feffffff02a7e50941010000001600147b3af2253632c3000f9cdd531747107fe249c7d1102700000000000017a91459fb638aaa55a7119a09faf5e8b2ce8a879cce338702473044022004666d885310990e1b0a61e93b1490acb172d43200d6fcfa22e89905b7f3094d02204a705e4a4fc8cab97f7d146f481e70718ee4567486796536d14c7808be3fd866012102cc3b01d2192b5275d3fda7f82eaf593dfb8ca9333f7296f93da401f8d1821335619f1e0001044751210226e53c7ab615da468364ca9f59879f51bd94278c26a39cac59a235a7cf8145932102d221e17bb80cf130bb0931434afac5e55f377ed9b2b003519a529ce02862444752ae22060226e53c7ab615da468364ca9f59879f51bd94278c26a39cac59a235a7cf81459314838f3ff92d000080000000000000000001000000220602d221e17bb80cf130bb0931434afac5e55f377ed9b2b003519a529ce02862444714e0c595c52d000080000000000000000001000000000000"
+        expected_unsigned_psbt_b64 = "cHNidP8BAHIBAAAAAaKU/3O6/slfNAtmfA8FuWi7qxpbFO1U0iiFGN7Bkbw7AQAAAAD/////AugDAAAAAAAAF6kUTpOd3+VnlxaS0ZVZ8fktT65aoFaHiBMAAAAAAAAWABT/naVn5i8w6oZU+h1fvUe++OO+EwAAAAAAAQDfAgAAAAABASxApoEPemcJE9Fx4fWyA8oB7UXtO/aLZJhQSR7stWAIAQAAAAD+////AqflCUEBAAAAFgAUezryJTYywwAPnN1TF0cQf+JJx9EQJwAAAAAAABepFFn7Y4qqVacRmgn69eiyzoqHnM4zhwJHMEQCIARmbYhTEJkOGwph6TsUkKyxctQyANb8+iLomQW38wlNAiBKcF5KT8jKuX99FG9IHnBxjuRWdIZ5ZTbRTHgIvj/YZgEhAsw7AdIZK1J10/2n+C6vWT37jKkzP3KW+T2kAfjRghM1YZ8eAAEER1EhAiblPHq2FdpGg2TKn1mHn1G9lCeMJqOcrFmiNafPgUWTIQLSIeF7uAzxMLsJMUNK+sXlXzd+2bKwA1GaUpzgKGJER1KuIgYCJuU8erYV2kaDZMqfWYefUb2UJ4wmo5ysWaI1p8+BRZMUg48/+S0AAIAAAAAAAAAAAAEAAAAiBgLSIeF7uAzxMLsJMUNK+sXlXzd+2bKwA1GaUpzgKGJERxTgxZXFLQAAgAAAAAAAAAAAAQAAAAAAAA=="
 
         # With p2sh, txid changes depending on which key signs
         tests = (
@@ -213,7 +212,7 @@ class P2SHTest(TestCase):
         # Now we prove we can sign this with either key
         for seed_word, signed_tx_hash_hex in tests:
             psbt_obj = create_ps2sh_multisig_psbt(**kwargs)
-            self.assertEqual(psbt_obj.serialize().hex(), expected_unsigned_psbt_hex)
+            self.assertEqual(psbt_obj.serialize_base64(), expected_unsigned_psbt_b64)
 
             hdpriv = HDPrivateKey.from_mnemonic(seed_word * 12, network="testnet")
 
@@ -250,7 +249,7 @@ class P2SHTest(TestCase):
         self.assertEqual(str(cm.exception), "xfp_hex deadbeef not found in psbt")
 
         psbt_obj.replace_root_xfps({"e0c595c5": "00000000"})
-        self.assertNotEqual(psbt_obj.serialize().hex(), expected_unsigned_psbt_hex)
+        self.assertNotEqual(psbt_obj.serialize_base64(), expected_unsigned_psbt_b64)
 
         # Confirm that swapping out the change address throws an error
         # nonsense address corresponding to secret exponent = 1

--- a/buidl/test/test_psbt_helper.py
+++ b/buidl/test/test_psbt_helper.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 
 from buidl.hd import HDPrivateKey
-from buidl.psbt import PSBT
 from buidl.psbt_helper import create_ps2sh_multisig_psbt
 from buidl.script import RedeemScript
 

--- a/buidl/test/test_psbt_helper.py
+++ b/buidl/test/test_psbt_helper.py
@@ -44,7 +44,6 @@ class P2SHTest(TestCase):
         # https://blockstream.info/testnet/tx/d8172be9981a4f57e6e4ebe0f4785f5f2035aee40ffbb2d6f1200810a879d490
 
         kwargs = {
-            "quorum_m": 1,
             "xpubs_dict": {
                 "e0c595c5": {
                     # action x12
@@ -59,6 +58,7 @@ class P2SHTest(TestCase):
             },
             "input_dicts": [
                 {
+                    "quorum_m": 1,
                     "path_dict": {
                         # xfp: child_path
                         "e0c595c5": "m/0/0",
@@ -132,7 +132,6 @@ class P2SHTest(TestCase):
 
         kwargs = {
             # this part is unchanged from the previous
-            "quorum_m": 1,
             "xpubs_dict": {
                 "e0c595c5": {
                     # action x12
@@ -148,6 +147,7 @@ class P2SHTest(TestCase):
             # this part is changed:
             "input_dicts": [
                 {
+                    "quorum_m": 1,
                     "path_dict": {
                         # xfp: child_path
                         "e0c595c5": "m/0/1",
@@ -166,6 +166,7 @@ class P2SHTest(TestCase):
                     # this should be change:
                     "sats": 1000,
                     "address": "2MzQhXqN93igSKGW9CMvkpZ9TYowWgiNEF8",
+                    "quorum_m": 1,
                     "path_dict": {
                         # xfp: child_path (m/1/* is receiving addr branch)
                         "e0c595c5": "m/1/0",

--- a/buidl/test/test_psbt_helper.py
+++ b/buidl/test/test_psbt_helper.py
@@ -176,7 +176,7 @@ class P2SHTest(TestCase):
                     "address": "2MzQhXqN93igSKGW9CMvkpZ9TYowWgiNEF8",
                     "quorum_m": 1,
                     "path_dict": {
-                        # xfp: root_path (m/1/* is receiving addr branch)
+                        # xfp: root_path (m/.../1/*/{idx} is receiving addr branch)
                         "e0c595c5": "m/45h/0/1/0",
                         "838f3ff9": "m/45h/0/1/0",
                     },

--- a/buidl/test/test_psbt_helper.py
+++ b/buidl/test/test_psbt_helper.py
@@ -13,7 +13,7 @@ class P2SHTest(TestCase):
         # For full details, see test_create_p2sh_multisig in test_script.py
 
         # Insecure testing BIP39 mnemonics
-        full_path = "m/45h/0/0/0"
+        root_path = "m/45h/0/0/0"
         hdprivs = [
             HDPrivateKey.from_mnemonic(seed_word * 12, network="testnet")
             for seed_word in ("action ", "agent ")
@@ -22,7 +22,7 @@ class P2SHTest(TestCase):
         # Validate the 0th receive address for m/45'/0
         expected_spending_addr = "2ND4qfpdHyeXJboAUkKZqJsyiKyXvHRKhbi"
         pubkey_hex_list = [
-            hdpriv.traverse(full_path).pub.sec().hex() for hdpriv in hdprivs
+            hdpriv.traverse(root_path).pub.sec().hex() for hdpriv in hdprivs
         ]
 
         redeem_script_to_use = RedeemScript.create_p2sh_multisig(
@@ -45,24 +45,28 @@ class P2SHTest(TestCase):
 
         kwargs = {
             "xpubs_dict": {
-                "e0c595c5": {
-                    # action x12
-                    "xpub_hex": "tpubDBnspiLZfrq1V7j1iuMxGiPsuHyy6e4QBnADwRrbH89AcnsUEMfWiAYXmSbMuNFsrMdnbQRDGGSM1AFGL6zUWNVSmwRavoJzdQBbZKLgLgd",
-                    "base_path": "m/45h/0",
-                },
-                "838f3ff9": {
-                    # agent x12
-                    "xpub_hex": "tpubDAKJicb9Tkw34PFLEBUcbnH99twN3augmg7oYHHx9Aa9iodXmA4wtGEJr8h2XjJYqn2j1v5qHLjpWEe8aPihmC6jmsgomsuc9Zeh4ZushNk",
-                    "base_path": "m/45h/0",
-                },
+                "e0c595c5": [
+                    {
+                        # action x12
+                        "xpub_hex": "tpubDBnspiLZfrq1V7j1iuMxGiPsuHyy6e4QBnADwRrbH89AcnsUEMfWiAYXmSbMuNFsrMdnbQRDGGSM1AFGL6zUWNVSmwRavoJzdQBbZKLgLgd",
+                        "base_path": "m/45h/0",
+                    }
+                ],
+                "838f3ff9": [
+                    {
+                        # agent x12
+                        "xpub_hex": "tpubDAKJicb9Tkw34PFLEBUcbnH99twN3augmg7oYHHx9Aa9iodXmA4wtGEJr8h2XjJYqn2j1v5qHLjpWEe8aPihmC6jmsgomsuc9Zeh4ZushNk",
+                        "base_path": "m/45h/0",
+                    }
+                ],
             },
             "input_dicts": [
                 {
                     "quorum_m": 1,
                     "path_dict": {
-                        # xfp: child_path
-                        "e0c595c5": "m/0/0",
-                        "838f3ff9": "m/0/0",
+                        # xfp: root_path
+                        "e0c595c5": "m/45'/0/0/0",
+                        "838f3ff9": "m/45'/0/0/0",
                     },
                     "prev_tx_dict": {
                         "hex": "02000000000101380bff9db676d159ad34849079c77e0d5c1df9c841b6a6640cba9bfc15077eea0100000000feffffff02008312000000000017a914d96bb9c5888f473dbd077d77009fb49ba2fda24287611c92a00100000017a9148722f07fbcf0fc506ea4ba9daa811d11396bbcfd870247304402202fe3c2f18e1486407bf0baabd2b3376102f0844a754d8e2fb8de71b39b3f76c702200c1fe8f7f9ef5165929ed51bf754edd7dd3e591921979cf5b891c841a1fd19d80121037c8fe1fa1ae4dfff522c532917c73c4884469e3b6a284e9a039ec612dca78eefd29c1e00",
@@ -103,7 +107,7 @@ class P2SHTest(TestCase):
 
             hdpriv = HDPrivateKey.from_mnemonic(seed_word * 12, network="testnet")
 
-            full_path_to_use = None
+            root_path_to_use = None
             for cnt, psbt_in in enumerate(psbt_obj.psbt_ins):
 
                 self.assertEqual(psbt_in.redeem_script.get_quorum(), (1, 2))
@@ -115,12 +119,12 @@ class P2SHTest(TestCase):
                         named_pubkey.root_fingerprint.hex()
                         == hdpriv.fingerprint().hex()
                     ):
-                        full_path_to_use = named_pubkey.root_path
+                        root_path_to_use = named_pubkey.root_path
 
                 # In this example, the path is the same regardless of which key we sign with:
-                self.assertEqual(full_path_to_use, "m/45'/0/0/0")
+                self.assertEqual(root_path_to_use, "m/45'/0/0/0")
 
-            private_keys = [hdpriv.traverse(full_path_to_use).private_key]
+            private_keys = [hdpriv.traverse(root_path_to_use).private_key]
 
             self.assertTrue(psbt_obj.sign_with_private_keys(private_keys=private_keys))
 
@@ -133,25 +137,29 @@ class P2SHTest(TestCase):
         kwargs = {
             # this part is unchanged from the previous
             "xpubs_dict": {
-                "e0c595c5": {
-                    # action x12
-                    "xpub_hex": "tpubDBnspiLZfrq1V7j1iuMxGiPsuHyy6e4QBnADwRrbH89AcnsUEMfWiAYXmSbMuNFsrMdnbQRDGGSM1AFGL6zUWNVSmwRavoJzdQBbZKLgLgd",
-                    "base_path": "m/45h/0",
-                },
-                "838f3ff9": {
-                    # agent x12
-                    "xpub_hex": "tpubDAKJicb9Tkw34PFLEBUcbnH99twN3augmg7oYHHx9Aa9iodXmA4wtGEJr8h2XjJYqn2j1v5qHLjpWEe8aPihmC6jmsgomsuc9Zeh4ZushNk",
-                    "base_path": "m/45h/0",
-                },
+                "e0c595c5": [
+                    {
+                        # action x12
+                        "xpub_hex": "tpubDBnspiLZfrq1V7j1iuMxGiPsuHyy6e4QBnADwRrbH89AcnsUEMfWiAYXmSbMuNFsrMdnbQRDGGSM1AFGL6zUWNVSmwRavoJzdQBbZKLgLgd",
+                        "base_path": "m/45h/0",
+                    }
+                ],
+                "838f3ff9": [
+                    {
+                        # agent x12
+                        "xpub_hex": "tpubDAKJicb9Tkw34PFLEBUcbnH99twN3augmg7oYHHx9Aa9iodXmA4wtGEJr8h2XjJYqn2j1v5qHLjpWEe8aPihmC6jmsgomsuc9Zeh4ZushNk",
+                        "base_path": "m/45h/0",
+                    }
+                ],
             },
             # this part is changed:
             "input_dicts": [
                 {
                     "quorum_m": 1,
                     "path_dict": {
-                        # xfp: child_path
-                        "e0c595c5": "m/0/1",
-                        "838f3ff9": "m/0/1",
+                        # xfp: root_path
+                        "e0c595c5": "m/45h/0/0/1",
+                        "838f3ff9": "m/45h/0/0/1",
                     },
                     "prev_tx_dict": {
                         "hex": "020000000001012c40a6810f7a670913d171e1f5b203ca01ed45ed3bf68b649850491eecb560080100000000feffffff02a7e50941010000001600147b3af2253632c3000f9cdd531747107fe249c7d1102700000000000017a91459fb638aaa55a7119a09faf5e8b2ce8a879cce338702473044022004666d885310990e1b0a61e93b1490acb172d43200d6fcfa22e89905b7f3094d02204a705e4a4fc8cab97f7d146f481e70718ee4567486796536d14c7808be3fd866012102cc3b01d2192b5275d3fda7f82eaf593dfb8ca9333f7296f93da401f8d1821335619f1e00",
@@ -168,9 +176,9 @@ class P2SHTest(TestCase):
                     "address": "2MzQhXqN93igSKGW9CMvkpZ9TYowWgiNEF8",
                     "quorum_m": 1,
                     "path_dict": {
-                        # xfp: child_path (m/1/* is receiving addr branch)
-                        "e0c595c5": "m/1/0",
-                        "838f3ff9": "m/1/0",
+                        # xfp: root_path (m/1/* is receiving addr branch)
+                        "e0c595c5": "m/45h/0/1/0",
+                        "838f3ff9": "m/45h/0/1/0",
                     },
                 },
                 {
@@ -207,7 +215,7 @@ class P2SHTest(TestCase):
 
             hdpriv = HDPrivateKey.from_mnemonic(seed_word * 12, network="testnet")
 
-            full_path_to_use = None
+            root_path_to_use = None
             for cnt, psbt_in in enumerate(psbt_obj.psbt_ins):
 
                 self.assertEqual(psbt_in.redeem_script.get_quorum(), (1, 2))
@@ -219,12 +227,12 @@ class P2SHTest(TestCase):
                         named_pubkey.root_fingerprint.hex()
                         == hdpriv.fingerprint().hex()
                     ):
-                        full_path_to_use = named_pubkey.root_path
+                        root_path_to_use = named_pubkey.root_path
 
                 # In this example, the path is the same regardless of which key we sign with:
-                self.assertEqual(full_path_to_use, "m/45'/0/0/1")
+                self.assertEqual(root_path_to_use, "m/45'/0/0/1")
 
-            private_keys = [hdpriv.traverse(full_path_to_use).private_key]
+            private_keys = [hdpriv.traverse(root_path_to_use).private_key]
 
             self.assertTrue(psbt_obj.sign_with_private_keys(private_keys=private_keys))
 

--- a/buidl/test/test_psbt_helper.py
+++ b/buidl/test/test_psbt_helper.py
@@ -93,22 +93,20 @@ class P2SHTest(TestCase):
         # d8172be9981a4f57e6e4ebe0f4785f5f2035aee40ffbb2d6f1200810a879d490 is the one that was broadcast to the testnet blockchain:
         # https://blockstream.info/testnet/tx/d8172be9981a4f57e6e4ebe0f4785f5f2035aee40ffbb2d6f1200810a879d490
 
-        psbt_instructions = {
+        kwargs = {
             "quorum_m": 1,
-            "xpub_dict_list": [
-                {
+            "xpubs_dict": {
+                "e0c595c5": {
                     # action x12
                     "xpub_hex": "tpubDBnspiLZfrq1V7j1iuMxGiPsuHyy6e4QBnADwRrbH89AcnsUEMfWiAYXmSbMuNFsrMdnbQRDGGSM1AFGL6zUWNVSmwRavoJzdQBbZKLgLgd",
-                    "fingerprint_hex": "e0c595c5",
                     "base_path": "m/45h/0",
                 },
-                {
+                "838f3ff9": {
                     # agent x12
                     "xpub_hex": "tpubDAKJicb9Tkw34PFLEBUcbnH99twN3augmg7oYHHx9Aa9iodXmA4wtGEJr8h2XjJYqn2j1v5qHLjpWEe8aPihmC6jmsgomsuc9Zeh4ZushNk",
-                    "fingerprint_hex": "838f3ff9",
                     "base_path": "m/45h/0",
                 },
-            ],
+            },
             "inputs_dict_list": [
                 {
                     "path_dict": {
@@ -150,10 +148,11 @@ class P2SHTest(TestCase):
 
         # Now we prove we can sign this with either key
         for seed_word, signed_tx_hash_hex in tests:
-            psbt_obj = create_ps2sh_multisig_psbt(**psbt_instructions)
+            psbt_obj = create_ps2sh_multisig_psbt(**kwargs)
             self.assertEqual(psbt_obj.serialize().hex(), expected_unsigned_psbt_hex)
 
             hdpriv = HDPrivateKey.from_mnemonic(seed_word * 12, network="testnet")
+
             private_keys = [hdpriv.traverse("m/45h/0/0/0").private_key]
 
             assert psbt_obj.sign_with_private_keys(private_keys=private_keys) is True

--- a/buidl/test/test_psbt_helper.py
+++ b/buidl/test/test_psbt_helper.py
@@ -1,0 +1,165 @@
+from unittest import TestCase
+
+from buidl.hd import HDPrivateKey
+from buidl.psbt import PSBT
+from buidl.psbt_helper import create_ps2sh_multisig_psbt
+from buidl.script import RedeemScript
+
+
+class P2SHTest(TestCase):
+    def test_receive_1of2(self):
+        # This is not strictly neccesary, just proving/showing how I received these testnet coins
+        # In the next test, I'll show to spend them
+        BASE_PATH = "m/45h/0"
+
+        # Insecure testing BIP39 mnemonics
+        hdpriv_root_1 = HDPrivateKey.from_mnemonic("action " * 12, network="testnet")
+        hdpriv_root_2 = HDPrivateKey.from_mnemonic("agent " * 12, network="testnet")
+
+        child_xpriv_1 = hdpriv_root_1.traverse(BASE_PATH)
+        child_xpriv_2 = hdpriv_root_2.traverse(BASE_PATH)
+
+        # xpubs from electrum:
+        self.assertEqual(
+            child_xpriv_1.xpub(),
+            "tpubDBnspiLZfrq1V7j1iuMxGiPsuHyy6e4QBnADwRrbH89AcnsUEMfWiAYXmSbMuNFsrMdnbQRDGGSM1AFGL6zUWNVSmwRavoJzdQBbZKLgLgd",
+        )
+        self.assertEqual(
+            child_xpriv_2.xpub(),
+            "tpubDAKJicb9Tkw34PFLEBUcbnH99twN3augmg7oYHHx9Aa9iodXmA4wtGEJr8h2XjJYqn2j1v5qHLjpWEe8aPihmC6jmsgomsuc9Zeh4ZushNk",
+        )
+
+        # addresses from electrum
+        expected_receive_addrs = [
+            "2ND4qfpdHyeXJboAUkKZqJsyiKyXvHRKhbi",
+            "2N1T1HAC9TnNvhEDG4oDEuKNnmdsXs2HNwq",
+            "2N7fdTu5JkQihTpo2mZ3QYudrfU2xMdgh3M",
+        ]
+        expected_change_addrs = [
+            "2MzQhXqN93igSKGW9CMvkpZ9TYowWgiNEF8",
+            "2Msk2ckm2Ee4kJnzQuyQtpYDpMZrXf5XtKD",
+            "2N5wXpJBKtAKSCiAZLwdh2sPwt5k2HBGtGC",
+        ]
+
+        # validate receive addrs match electrum
+        for cnt, expected_receive_addr in enumerate(expected_receive_addrs):
+            pubkey_hex_list = [
+                child_xpriv_1.traverse(f"m/0/{cnt}").pub.sec().hex(),
+                child_xpriv_2.traverse(f"m/0/{cnt}").pub.sec().hex(),
+            ]
+            redeem_script = RedeemScript.create_p2sh_multisig(
+                quorum_m=1,
+                # Electrum sorts lexographically:
+                pubkey_hex_list=sorted(pubkey_hex_list),
+            )
+            derived_addr = redeem_script.address(network="testnet")
+            self.assertEqual(derived_addr, expected_receive_addr)
+
+        # validate change addrs match electrum
+        for cnt, expected_change_addr in enumerate(expected_change_addrs):
+            pubkey_hex_list = [
+                child_xpriv_1.traverse(f"m/1/{cnt}").pub.sec().hex(),
+                child_xpriv_2.traverse(f"m/1/{cnt}").pub.sec().hex(),
+            ]
+            redeem_script = RedeemScript.create_p2sh_multisig(
+                quorum_m=1,
+                # Electrum sorts lexographically:
+                pubkey_hex_list=sorted(pubkey_hex_list),
+            )
+            derived_addr = redeem_script.address(network="testnet")
+            self.assertEqual(derived_addr, expected_change_addr)
+
+        # Validate the 0th receive address for m/45'/0
+        expected_spending_addr = "2ND4qfpdHyeXJboAUkKZqJsyiKyXvHRKhbi"
+        child_path_to_use = "m/0/0"
+        pubkey_hex_list = [
+            child_xpriv.traverse(child_path_to_use).pub.sec().hex()
+            for child_xpriv in (child_xpriv_1, child_xpriv_2)
+        ]
+        pubkey_hex_list.sort()
+
+        redeem_script_to_use = RedeemScript.create_p2sh_multisig(
+            quorum_m=1, pubkey_hex_list=pubkey_hex_list
+        )
+        self.assertEqual(
+            expected_spending_addr, redeem_script_to_use.address(network="testnet")
+        )
+
+        # Faucet TX I sent myself to this address:
+        # https://blockstream.info/testnet/tx/4412d2a7664d01bb784a0a359e9aacf160ee436067c6a42dca355da4817ca7da
+
+    def test_spend_1of2_p2sh(self):
+
+        # This test will produce a validly signed TX for the 1-of-2 p2sh using either key
+
+        # Note: d8172be9981a4f57e6e4ebe0f4785f5f2035aee40ffbb2d6f1200810a879d490 is the one that was broadcast to the testnet blockchain:
+        # https://blockstream.info/testnet/tx/d8172be9981a4f57e6e4ebe0f4785f5f2035aee40ffbb2d6f1200810a879d490
+
+        psbt_instructions = {
+            "quorum_m": 1,
+            "xpub_dict_list": [
+                {
+                    # action x12
+                    "xpub_hex": "tpubDBnspiLZfrq1V7j1iuMxGiPsuHyy6e4QBnADwRrbH89AcnsUEMfWiAYXmSbMuNFsrMdnbQRDGGSM1AFGL6zUWNVSmwRavoJzdQBbZKLgLgd",
+                    "fingerprint_hex": "e0c595c5",
+                    "base_path": "m/45h/0",
+                },
+                {
+                    # agent x12
+                    "xpub_hex": "tpubDAKJicb9Tkw34PFLEBUcbnH99twN3augmg7oYHHx9Aa9iodXmA4wtGEJr8h2XjJYqn2j1v5qHLjpWEe8aPihmC6jmsgomsuc9Zeh4ZushNk",
+                    "fingerprint_hex": "838f3ff9",
+                    "base_path": "m/45h/0",
+                },
+            ],
+            "inputs_dict_list": [
+                {
+                    "path_dict": {
+                        # xfp: child_path
+                        "e0c595c5": "m/0/0",
+                        "838f3ff9": "m/0/0",
+                    },
+                    "prev_tx_dict": {
+                        "hex": "02000000000101380bff9db676d159ad34849079c77e0d5c1df9c841b6a6640cba9bfc15077eea0100000000feffffff02008312000000000017a914d96bb9c5888f473dbd077d77009fb49ba2fda24287611c92a00100000017a9148722f07fbcf0fc506ea4ba9daa811d11396bbcfd870247304402202fe3c2f18e1486407bf0baabd2b3376102f0844a754d8e2fb8de71b39b3f76c702200c1fe8f7f9ef5165929ed51bf754edd7dd3e591921979cf5b891c841a1fd19d80121037c8fe1fa1ae4dfff522c532917c73c4884469e3b6a284e9a039ec612dca78eefd29c1e00",
+                        "hash_hex": "4412d2a7664d01bb784a0a359e9aacf160ee436067c6a42dca355da4817ca7da",
+                        "output_idx": 0,
+                        "output_sats": 1213184,
+                    },
+                },
+            ],
+            "outputs_dict_list": [
+                {
+                    "sats": 999500,
+                    "address": "mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",  # TODO: logic to go from script to addr
+                },
+            ],
+            "fee_sats": 213684,
+            "network": "testnet",
+        }
+
+        expected_unsigned_psbt_hex = "70736274ff01005801000000000101daa77c81a45d35ca2da4c6676043ee60f1ac9a9e350a4a78bb014d66a7d212440000000000ffffffff014c400f00000000001976a914344a0f48ca150ec2b903817660b9b68b13a6702688ac0000000000000100e002000000000101380bff9db676d159ad34849079c77e0d5c1df9c841b6a6640cba9bfc15077eea0100000000feffffff02008312000000000017a914d96bb9c5888f473dbd077d77009fb49ba2fda24287611c92a00100000017a9148722f07fbcf0fc506ea4ba9daa811d11396bbcfd870247304402202fe3c2f18e1486407bf0baabd2b3376102f0844a754d8e2fb8de71b39b3f76c702200c1fe8f7f9ef5165929ed51bf754edd7dd3e591921979cf5b891c841a1fd19d80121037c8fe1fa1ae4dfff522c532917c73c4884469e3b6a284e9a039ec612dca78eefd29c1e00010447512102139f7167f17da94d24df6fe2868cdb5edabd0cff83ab487c942ea2f07570d9f021023cb71c699990768c018df17a366c4eb74bde169f29e884261c10c973ec26ad3a52ae220602139f7167f17da94d24df6fe2868cdb5edabd0cff83ab487c942ea2f07570d9f014838f3ff92d0000800000000000000000000000002206023cb71c699990768c018df17a366c4eb74bde169f29e884261c10c973ec26ad3a14e0c595c52d0000800000000000000000000000000000"
+
+        tests = (
+            # seed_word (repeated 12x), signed_tx_hash_hex
+            (
+                "action ",
+                "d8172be9981a4f57e6e4ebe0f4785f5f2035aee40ffbb2d6f1200810a879d490",
+            ),  # this is the one we broadcasted
+            (
+                "agent ",
+                "c38dcee54f40193d668c8911eeba7ec20f570fdbdb31fbe4351f66d7005c7bfb",
+            ),
+        )
+
+        # Now we prove we can sign this with either key
+        for seed_word, signed_tx_hash_hex in tests:
+            psbt_obj = create_ps2sh_multisig_psbt(**psbt_instructions)
+            self.assertEqual(psbt_obj.serialize().hex(), expected_unsigned_psbt_hex)
+
+            hdpriv = HDPrivateKey.from_mnemonic(seed_word * 12, network="testnet")
+            private_keys = [hdpriv.traverse("m/45h/0/0/0").private_key]
+
+            assert psbt_obj.sign_with_private_keys(private_keys=private_keys) is True
+
+            psbt_obj.finalize()
+
+            assert psbt_obj.final_tx().hash().hex() == signed_tx_hash_hex

--- a/buidl/test/test_psbt_helper.py
+++ b/buidl/test/test_psbt_helper.py
@@ -172,11 +172,11 @@ class P2SHTest(TestCase):
 
             private_keys = [hdpriv.traverse(full_path_to_use).private_key]
 
-            assert psbt_obj.sign_with_private_keys(private_keys=private_keys) is True
+            self.assertTrue(psbt_obj.sign_with_private_keys(private_keys=private_keys))
 
             psbt_obj.finalize()
 
-            assert psbt_obj.final_tx().hash().hex() == signed_tx_hash_hex
+            self.assertEqual(psbt_obj.final_tx().hash().hex(), signed_tx_hash_hex)
 
         # TODO fresh test with broadcast to blockchain
 
@@ -233,8 +233,8 @@ class P2SHTest(TestCase):
 
             private_keys = [hdpriv.traverse(full_path_to_use).private_key]
 
-            assert psbt_obj.sign_with_private_keys(private_keys=private_keys) is True
+            self.assertTrue(psbt_obj.sign_with_private_keys(private_keys=private_keys))
 
             psbt_obj.finalize()
 
-            assert psbt_obj.final_tx().hash().hex() == signed_tx_hash_hex
+            self.assertEqual(psbt_obj.final_tx().hash().hex(), signed_tx_hash_hex)

--- a/buidl/test/test_psbt_helper.py
+++ b/buidl/test/test_psbt_helper.py
@@ -7,7 +7,7 @@ from buidl.script import RedeemScript
 
 class P2SHTest(TestCase):
     def test_receive_1of2(self):
-        # This is not strictly neccesary, just proving/showing how I received these testnet coins
+        # This test is not strictly neccesary, it just provs/shows how I generated the testnet address that received these coins
         # In the next test, I'll show to spend them
         BASE_PATH = "m/45h/0"
 
@@ -42,28 +42,28 @@ class P2SHTest(TestCase):
 
         # validate receive addrs match electrum
         for cnt, expected_receive_addr in enumerate(expected_receive_addrs):
-            pubkey_hex_list = [
-                child_xpriv_1.traverse(f"m/0/{cnt}").pub.sec().hex(),
-                child_xpriv_2.traverse(f"m/0/{cnt}").pub.sec().hex(),
-            ]
             redeem_script = RedeemScript.create_p2sh_multisig(
                 quorum_m=1,
-                # Electrum sorts lexographically:
-                pubkey_hex_list=sorted(pubkey_hex_list),
+                pubkey_hex_list=[
+                    child_xpriv_1.traverse(f"m/0/{cnt}").pub.sec().hex(),
+                    child_xpriv_2.traverse(f"m/0/{cnt}").pub.sec().hex(),
+                ],
+                # Electrum sorts child pubkeys lexicographically:
+                sort_keys=True,
             )
             derived_addr = redeem_script.address(network="testnet")
             self.assertEqual(derived_addr, expected_receive_addr)
 
         # validate change addrs match electrum
         for cnt, expected_change_addr in enumerate(expected_change_addrs):
-            pubkey_hex_list = [
-                child_xpriv_1.traverse(f"m/1/{cnt}").pub.sec().hex(),
-                child_xpriv_2.traverse(f"m/1/{cnt}").pub.sec().hex(),
-            ]
             redeem_script = RedeemScript.create_p2sh_multisig(
                 quorum_m=1,
-                # Electrum sorts lexographically:
-                pubkey_hex_list=sorted(pubkey_hex_list),
+                pubkey_hex_list=[
+                    child_xpriv_1.traverse(f"m/1/{cnt}").pub.sec().hex(),
+                    child_xpriv_2.traverse(f"m/1/{cnt}").pub.sec().hex(),
+                ],
+                # Electrum sorts lexicographically:
+                sort_keys=True,
             )
             derived_addr = redeem_script.address(network="testnet")
             self.assertEqual(derived_addr, expected_change_addr)
@@ -89,9 +89,8 @@ class P2SHTest(TestCase):
 
     def test_spend_1of2_p2sh(self):
 
-        # This test will produce a validly signed TX for the 1-of-2 p2sh using either key
-
-        # Note: d8172be9981a4f57e6e4ebe0f4785f5f2035aee40ffbb2d6f1200810a879d490 is the one that was broadcast to the testnet blockchain:
+        # This test will produce a validly signed TX for the 1-of-2 p2sh using either key, which will result in a different TX ID
+        # d8172be9981a4f57e6e4ebe0f4785f5f2035aee40ffbb2d6f1200810a879d490 is the one that was broadcast to the testnet blockchain:
         # https://blockstream.info/testnet/tx/d8172be9981a4f57e6e4ebe0f4785f5f2035aee40ffbb2d6f1200810a879d490
 
         psbt_instructions = {
@@ -128,21 +127,21 @@ class P2SHTest(TestCase):
             "outputs_dict_list": [
                 {
                     "sats": 999500,
-                    "address": "mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",  # TODO: logic to go from script to addr
+                    "address": "mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
                 },
             ],
             "fee_sats": 213684,
-            "network": "testnet",
         }
 
         expected_unsigned_psbt_hex = "70736274ff01005801000000000101daa77c81a45d35ca2da4c6676043ee60f1ac9a9e350a4a78bb014d66a7d212440000000000ffffffff014c400f00000000001976a914344a0f48ca150ec2b903817660b9b68b13a6702688ac0000000000000100e002000000000101380bff9db676d159ad34849079c77e0d5c1df9c841b6a6640cba9bfc15077eea0100000000feffffff02008312000000000017a914d96bb9c5888f473dbd077d77009fb49ba2fda24287611c92a00100000017a9148722f07fbcf0fc506ea4ba9daa811d11396bbcfd870247304402202fe3c2f18e1486407bf0baabd2b3376102f0844a754d8e2fb8de71b39b3f76c702200c1fe8f7f9ef5165929ed51bf754edd7dd3e591921979cf5b891c841a1fd19d80121037c8fe1fa1ae4dfff522c532917c73c4884469e3b6a284e9a039ec612dca78eefd29c1e00010447512102139f7167f17da94d24df6fe2868cdb5edabd0cff83ab487c942ea2f07570d9f021023cb71c699990768c018df17a366c4eb74bde169f29e884261c10c973ec26ad3a52ae220602139f7167f17da94d24df6fe2868cdb5edabd0cff83ab487c942ea2f07570d9f014838f3ff92d0000800000000000000000000000002206023cb71c699990768c018df17a366c4eb74bde169f29e884261c10c973ec26ad3a14e0c595c52d0000800000000000000000000000000000"
 
         tests = (
-            # seed_word (repeated 12x), signed_tx_hash_hex
+            # (seed_word repeated x12, signed_tx_hash_hex),
             (
+                # this is the one we broadcasted
                 "action ",
                 "d8172be9981a4f57e6e4ebe0f4785f5f2035aee40ffbb2d6f1200810a879d490",
-            ),  # this is the one we broadcasted
+            ),
             (
                 "agent ",
                 "c38dcee54f40193d668c8911eeba7ec20f570fdbdb31fbe4351f66d7005c7bfb",

--- a/buidl/test/test_psbt_helper.py
+++ b/buidl/test/test_psbt_helper.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 from copy import deepcopy
 
 from buidl.hd import HDPrivateKey
-from buidl.psbt_helper import create_ps2sh_multisig_psbt
+from buidl.psbt_helper import create_p2sh_multisig_psbt
 from buidl.script import RedeemScript
 
 
@@ -103,7 +103,7 @@ class P2SHTest(TestCase):
 
         # Now we prove we can sign this with either key
         for seed_word, signed_tx_hash_hex in tests:
-            psbt_obj = create_ps2sh_multisig_psbt(**kwargs)
+            psbt_obj = create_p2sh_multisig_psbt(**kwargs)
             self.assertEqual(psbt_obj.serialize_base64(), expected_unsigned_psbt_b64)
 
             hdpriv = HDPrivateKey.from_mnemonic(seed_word * 12, network="testnet")
@@ -211,7 +211,7 @@ class P2SHTest(TestCase):
 
         # Now we prove we can sign this with either key
         for seed_word, signed_tx_hash_hex in tests:
-            psbt_obj = create_ps2sh_multisig_psbt(**kwargs)
+            psbt_obj = create_p2sh_multisig_psbt(**kwargs)
             self.assertEqual(psbt_obj.serialize_base64(), expected_unsigned_psbt_b64)
 
             hdpriv = HDPrivateKey.from_mnemonic(seed_word * 12, network="testnet")
@@ -242,7 +242,7 @@ class P2SHTest(TestCase):
             self.assertEqual(psbt_obj.final_tx().hash().hex(), signed_tx_hash_hex)
 
         # Replace xfps
-        psbt_obj = create_ps2sh_multisig_psbt(**kwargs)
+        psbt_obj = create_p2sh_multisig_psbt(**kwargs)
         with self.assertRaises(ValueError) as cm:
             # deadbeef  not in psbt
             psbt_obj.replace_root_xfps({"deadbeef": "00000000"})
@@ -257,7 +257,7 @@ class P2SHTest(TestCase):
         fake_addr = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
         modified_kwargs["output_dicts"][0]["address"] = fake_addr
         with self.assertRaises(ValueError) as cm:
-            create_ps2sh_multisig_psbt(**modified_kwargs)
+            create_p2sh_multisig_psbt(**modified_kwargs)
         self.assertEqual(
             "Invalid redeem script for output #0. Expecting 2MzQhXqN93igSKGW9CMvkpZ9TYowWgiNEF8 but got tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
             str(cm.exception),
@@ -269,7 +269,7 @@ class P2SHTest(TestCase):
         modified_kwargs = deepcopy(kwargs)
         modified_kwargs["output_dicts"][0]["path_dict"]["e0c595c5"] = "m/999"
         with self.assertRaises(ValueError) as cm:
-            create_ps2sh_multisig_psbt(**modified_kwargs)
+            create_p2sh_multisig_psbt(**modified_kwargs)
         self.assertIn(
             "xfp_hex e0c595c5 for m/999 from output #0 not supplied in xpubs_dict",
             str(cm.exception),

--- a/buidl/test/test_psbt_helper.py
+++ b/buidl/test/test_psbt_helper.py
@@ -7,7 +7,7 @@ from buidl.script import RedeemScript
 
 class P2SHTest(TestCase):
     def test_receive_1of2(self):
-        # This test is not strictly neccesary, it just provs/shows how I generated the testnet address that received these coins
+        # This test is not strictly neccesary, it just proves/shows how I generated the testnet address that received these coins
         # In the next test, I'll show to spend them
         BASE_PATH = "m/45h/0"
 

--- a/buidl/test/test_script.py
+++ b/buidl/test/test_script.py
@@ -111,7 +111,7 @@ class RedeemScriptTest(TestCase):
         for cnt, expected_receive_addr in enumerate(expected_receive_addrs):
             redeem_script = RedeemScript.create_p2sh_multisig(
                 quorum_m=1,
-                pubkey_hex_list=[
+                pubkey_hexes=[
                     child_xpriv_1.traverse(f"m/0/{cnt}").pub.sec().hex(),
                     child_xpriv_2.traverse(f"m/0/{cnt}").pub.sec().hex(),
                 ],
@@ -125,7 +125,7 @@ class RedeemScriptTest(TestCase):
         for cnt, expected_change_addr in enumerate(expected_change_addrs):
             redeem_script = RedeemScript.create_p2sh_multisig(
                 quorum_m=1,
-                pubkey_hex_list=[
+                pubkey_hexes=[
                     child_xpriv_1.traverse(f"m/1/{cnt}").pub.sec().hex(),
                     child_xpriv_2.traverse(f"m/1/{cnt}").pub.sec().hex(),
                 ],
@@ -137,13 +137,13 @@ class RedeemScriptTest(TestCase):
 
         # For recovery only (unsorted pubkeys), do not use this method unless you know what you're doing
         misordered_pubkeys_addr = "2NFzScjC9jaMbo5ST4M1WVeeWgSaVT7xS1W"
-        pubkey_hex_list = [
+        pubkey_hexes = [
             child_xpriv_1.traverse("m/0/0").pub.sec().hex(),
             child_xpriv_2.traverse("m/0/0").pub.sec().hex(),
         ]
         misordered_redeem_script = RedeemScript.create_p2sh_multisig_unsorted(
             quorum_m=1,
-            pubkey_hex_list=pubkey_hex_list,
+            pubkey_hexes=pubkey_hexes,
             target_address=misordered_pubkeys_addr,
             network="testnet",
         )
@@ -155,7 +155,7 @@ class RedeemScriptTest(TestCase):
             fake_addr = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
             RedeemScript.create_p2sh_multisig_unsorted(
                 quorum_m=1,
-                pubkey_hex_list=pubkey_hex_list,
+                pubkey_hexes=pubkey_hexes,
                 target_address=fake_addr,
                 network="testnet",
             )

--- a/buidl/test/test_script.py
+++ b/buidl/test/test_script.py
@@ -138,8 +138,8 @@ class RedeemScriptTest(TestCase):
         # For recovery only (unsorted pubkeys), do not use this method unless you know what you're doing
         misordered_pubkeys_addr = "2NFzScjC9jaMbo5ST4M1WVeeWgSaVT7xS1W"
         pubkey_hex_list = [
-            child_xpriv_1.traverse(f"m/0/0").pub.sec().hex(),
-            child_xpriv_2.traverse(f"m/0/0").pub.sec().hex(),
+            child_xpriv_1.traverse("m/0/0").pub.sec().hex(),
+            child_xpriv_2.traverse("m/0/0").pub.sec().hex(),
         ]
         misordered_redeem_script = RedeemScript.create_p2sh_multisig_unsorted(
             quorum_m=1,
@@ -147,10 +147,13 @@ class RedeemScriptTest(TestCase):
             target_address=misordered_pubkeys_addr,
             network="testnet",
         )
+        self.assertEqual(
+            misordered_redeem_script.address("testnet"), misordered_pubkeys_addr
+        )
 
         with self.assertRaises(ValueError):
             fake_addr = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
-            misordered_redeem_script = RedeemScript.create_p2sh_multisig_unsorted(
+            RedeemScript.create_p2sh_multisig_unsorted(
                 quorum_m=1,
                 pubkey_hex_list=pubkey_hex_list,
                 target_address=fake_addr,

--- a/buidl/test/test_tx.py
+++ b/buidl/test/test_tx.py
@@ -226,7 +226,7 @@ class TxTest(TestCase):
 
         redeem_script = RedeemScript.create_p2sh_multisig(
             quorum_m=2,
-            pubkey_hex_list=[
+            pubkey_hexes=[
                 private_key1.point.sec().hex(),
                 private_key2.point.sec().hex(),
             ],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="buidl",
-    version="0.2.20",
+    version="0.2.21",
     author="Example Author",
     author_email="author@example.com",
     description="An easy-to-use and fully featured bitcoin library written in pure python (no dependencies).",


### PR DESCRIPTION
UPDATE: Finally ready to merge!

Things missing (see `TODO`s in code):
- [x] Change detection (https://github.com/buidl-bitcoin/buidl-python/pull/81/commits/7c91e98b83c5cfc671d7d3d46076819e4d59a3d7 and earlier)
- [x] Add support for non-lexicographical ordering of child pubkeys
- [x] Better variable names. UPDATE: done in https://github.com/buidl-bitcoin/buidl-python/pull/81/commits/531bb1ab8e1791cbbbd482bc4fc613acc55ae7cb
- [x] Add optional `target_addr` argument to `create_p2sh_multisig` method for safety (done in https://github.com/buidl-bitcoin/buidl-python/pull/81/commits/3b939190d1113c7d494609608407ea7cf85548f8)

No
* ~~Have option to only require the prev_hash/idx/amount and not the full tx hex for all UTXOs?~~ This isn't compatible with coldcard, so *not* going to do this for now.
