### PR TITLE
Added Multisig Taproot Support

### DIFF
--- a/buidl/__init__.py
+++ b/buidl/__init__.py
@@ -18,5 +18,6 @@ from .psbt import *
 from .psbt_helper import *
 from .script import *
 from .shamir import *
+from .taproot import *
 from .tx import *
 from .witness import *

--- a/buidl/hd.py
+++ b/buidl/hd.py
@@ -122,8 +122,8 @@ class HDPrivateKey:
     def address(self):
         return self.pub.address()
 
-    def bech32_address(self):
-        return self.pub.bech32_address()
+    def p2wpkh_address(self):
+        return self.pub.p2wpkh_address()
 
     def p2sh_p2wpkh_address(self):
         return self.pub.p2sh_p2wpkh_address()
@@ -332,9 +332,9 @@ class HDPrivateKey:
         # if 49', return the p2sh_p2wpkh_address
         elif purpose == "49'":
             return point.p2sh_p2wpkh_address(network=self.network)
-        # if 84', return the bech32_address
+        # if 84', return the p2wpkh_address
         elif purpose == "84'":
-            return point.bech32_address(network=self.network)
+            return point.p2wpkh_address(network=self.network)
         # if 86', return the p2tr_address
         elif purpose == "86'":
             return point.p2tr_address(network=self.network)
@@ -510,8 +510,8 @@ class HDPublicKey:
     def address(self):
         return self.point.address(network=self.network)
 
-    def bech32_address(self):
-        return self.point.bech32_address(network=self.network)
+    def p2wpkh_address(self):
+        return self.point.p2wpkh_address(network=self.network)
 
     def p2sh_p2wpkh_address(self):
         return self.point.p2sh_p2wpkh_address(network=self.network)

--- a/buidl/libsec.h
+++ b/buidl/libsec.h
@@ -39,7 +39,12 @@ int secp256k1_ec_pubkey_tweak_mul(
     secp256k1_pubkey *pubkey,
     const unsigned char *tweak
 );
-
+int secp256k1_ec_pubkey_combine(
+    const secp256k1_context* ctx,
+    secp256k1_pubkey *out,
+    const secp256k1_pubkey * const * ins,
+    size_t n
+);
 typedef struct {
     unsigned char data[64];
 } secp256k1_ecdsa_signature;

--- a/buidl/script.py
+++ b/buidl/script.py
@@ -256,8 +256,10 @@ class Script:
                         tweak_point = control_block.tweak_point(tap_leaf)
                         # the tweak point should be what's on the stack
                         if tweak_point.parity != control_block.parity:
+                            print("bad tweak point parity")
                             return False
                         if tweak_point.bip340() != stack.pop():
+                            print("bad tweak point")
                             return False
                         # pop off the 1 and start fresh
                         stack.pop()
@@ -527,7 +529,9 @@ class P2TRScriptPubKey(ScriptPubKey):
         elif type(point) == bytes:
             raw_point = point
         else:
-            raise TypeError("To initialize P2TRScriptPubKey, a point is needed")
+            raise TypeError(
+                f"To initialize P2TRScriptPubKey, a point is needed {point}"
+            )
         self.commands = [0x51, raw_point]
 
     def address(self, network="mainnet"):
@@ -537,17 +541,10 @@ class P2TRScriptPubKey(ScriptPubKey):
         # convert to bech32 address using encode_bech32_checksum
         return encode_bech32_checksum(witness_program, network)
 
-
-class P2PKTapScript(ScriptPubKey):
-    def __init__(self, point):
-        super().__init__()
-        if type(point) == S256Point:
-            raw_point = point.bip340()
-        elif type(point) == bytes:
-            raw_point = point
-        else:
-            raise TypeError(f"To initialize P2PKTapScript, a point is needed {point}")
-        self.commands = [raw_point, 0xAC]
+    @classmethod
+    def from_address(cls, address):
+        _, _, point_raw = decode_bech32(address)
+        return cls(point_raw)
 
 
 class WitnessScript(Script):

--- a/buidl/test/test_hd.py
+++ b/buidl/test/test_hd.py
@@ -23,7 +23,7 @@ class HDTest(TestCase):
         }
         for network, want in tests.items():
             priv = HDPrivateKey.from_seed(seed, network=network)
-            addr = priv.bech32_address()
+            addr = priv.p2wpkh_address()
             self.assertEqual(addr, want)
 
     def test_child(self):
@@ -48,11 +48,11 @@ class HDTest(TestCase):
         for network, want1, want2 in tests:
             priv = HDPrivateKey.from_seed(seed, network=network)
             pub = priv.pub
-            addr = priv.child(0).bech32_address()
+            addr = priv.child(0).p2wpkh_address()
             self.assertEqual(addr, want1)
-            addr = pub.child(0).bech32_address()
+            addr = pub.child(0).p2wpkh_address()
             self.assertEqual(addr, want1)
-            addr = priv.child(0x80000002).bech32_address()
+            addr = priv.child(0x80000002).p2wpkh_address()
             self.assertEqual(addr, want2)
             with self.assertRaises(ValueError):
                 pub.child(0x80000002)
@@ -69,12 +69,12 @@ class HDTest(TestCase):
             pub = priv.pub
             path = "m/1/2/3/4"
             self.assertEqual(
-                priv.traverse(path).bech32_address(),
-                pub.traverse(path).bech32_address(),
+                priv.traverse(path).p2wpkh_address(),
+                pub.traverse(path).p2wpkh_address(),
             )
             path = "m/0/1'/2/3'"
             self.assertEqual(
-                priv.traverse(path).bech32_address(),
+                priv.traverse(path).p2wpkh_address(),
                 want,
             )
 
@@ -462,7 +462,7 @@ class HDTest(TestCase):
         self.assertEqual(account0_first_key.private_key.point.sec(), want)
         self.assertEqual(pub_first_key.address(), account0_first_key.address())
 
-    def test_bech32_address(self):
+    def test_p2wpkh_address(self):
         mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
         password = b""
         path = "m/84'/0'/0'"
@@ -475,7 +475,7 @@ class HDTest(TestCase):
         self.assertEqual(account.xpub(version=bytes.fromhex("04b24746")), want)
         first_key = account.child(0).child(0)
         want = "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
-        self.assertEqual(first_key.bech32_address(), want)
+        self.assertEqual(first_key.p2wpkh_address(), want)
 
     def test_p2tr_address(self):
         mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"

--- a/buidl/test/test_musig.py
+++ b/buidl/test/test_musig.py
@@ -1,0 +1,340 @@
+from itertools import combinations
+from random import randint
+from unittest import TestCase
+
+from buidl.ecc import N, G, S256Point
+from buidl.hd import HDPrivateKey
+from buidl.helper import SIGHASH_DEFAULT
+from buidl.taproot import MultiSigTapScript, MuSigTapScript, TapRootMultiSig
+from buidl.tx import Tx, TxIn, TxOut
+from buidl.witness import Witness
+
+
+class MuSigTest(TestCase):
+    def test_single_leaf_multisig(self):
+        hd_priv_key = HDPrivateKey.from_mnemonic(
+            "oil oil oil oil oil oil oil oil oil oil oil oil", network="signet"
+        )
+        # create a 3-of-5 single-leaf multisig
+        private_keys = [
+            hd_priv_key.get_p2tr_receiving_privkey(address=i) for i in range(5)
+        ]
+        points = [priv.point for priv in private_keys]
+        tr_multisig = TapRootMultiSig(points, 3)
+        tap_root_input = tr_multisig.single_leaf_tap_root()
+        tap_root_output = tr_multisig.multi_leaf_tap_root()
+        leaf = tap_root_input.tap_node
+        self.assertEqual(
+            tap_root_input.address(network="signet"),
+            "tb1p9gpzhc5fhlwlf49ze00fgjszxh5pl2p7az76758xwarweq08gcas8qa0r7",
+        )
+        prev_tx = bytes.fromhex(
+            "9baaec56eeef80bfa9c0f9c039fb71f134973179a3e2c3e8d037a4cc29cf6354"
+        )
+        tx_ins = []
+        for prev_index in range(10):
+            tx_in = TxIn(prev_tx, prev_index)
+            tx_in._value = 999130
+            tx_in._script_pubkey = tap_root_input.script_pubkey()
+            tx_ins.append(tx_in)
+        tx_out = TxOut(tx_in.value() - 200, tap_root_output.script_pubkey())
+        tx_obj = Tx(1, tx_ins, [tx_out] * 10, 0, network="signet", segwit=True)
+        for input_index, pubkeys in enumerate(combinations(points, 3)):
+            tx_in = tx_ins[input_index]
+            tx_in.witness.items = []
+            tx_obj.initialize_p2tr_multisig(
+                input_index,
+                tap_root_input.control_block(leaf),
+                tap_root_input.tap_node.tap_script,
+            )
+            sigs = []
+            for priv in private_keys:
+                if priv.point in pubkeys:
+                    sig = tx_obj.get_sig_taproot(input_index, priv, ext_flag=1)
+                else:
+                    sig = b""
+                sigs.append(sig)
+            tx_obj.finalize_p2tr_multisig(input_index, sigs)
+            self.assertTrue(tx_obj.verify_input(input_index))
+        self.assertTrue(tx_obj.verify())
+
+    def test_multi_leaf_multisig(self):
+        hd_priv_key = HDPrivateKey.from_mnemonic(
+            "oil oil oil oil oil oil oil oil oil oil oil oil", network="signet"
+        )
+        # create a 3-of-5 multi-leaf multisig
+        private_keys = [
+            hd_priv_key.get_p2tr_receiving_privkey(address=i) for i in range(5)
+        ]
+        points = [priv.point for priv in private_keys]
+        multisig = TapRootMultiSig(points, 3)
+        tap_root_input = multisig.multi_leaf_tap_root()
+        tap_root_output = multisig.musig_tap_root()
+        self.assertEqual(
+            tap_root_input.address(network="signet"),
+            "tb1p7e95u84xfjeuyndvpzauavkw59m2r9ekw28xxax3cftgzx3kza8q7ruv3u",
+        )
+        prev_tx = bytes.fromhex(
+            "ee78952b6baa1cb2b04f174a0f3e7f536828062e2ce41341e2d2c079e2b83e74"
+        )
+        tx_ins = []
+        for prev_index in range(10):
+            tx_in = TxIn(prev_tx, prev_index)
+            tx_in._value = 998930
+            tx_in._script_pubkey = tap_root_input.script_pubkey()
+            tx_ins.append(tx_in)
+        tx_out = TxOut(tx_in.value() - 200, tap_root_output.script_pubkey())
+        tx_obj = Tx(1, tx_ins, [tx_out] * 10, 0, network="signet", segwit=True)
+        for input_index, pubkeys in enumerate(combinations(points, 3)):
+            tx_in = tx_ins[input_index]
+            tx_in.witness.items = []
+            leaf = MultiSigTapScript(pubkeys, 3).tap_leaf()
+            self.assertTrue(tap_root_input.control_block(leaf))
+            tx_obj.initialize_p2tr_multisig(
+                input_index, tap_root_input.control_block(leaf), leaf.tap_script
+            )
+            sigs = []
+            for priv in private_keys:
+                if priv.point in pubkeys:
+                    sig = tx_obj.get_sig_taproot(input_index, priv, ext_flag=1)
+                    sigs.append(sig)
+            tx_obj.finalize_p2tr_multisig(input_index, sigs)
+            self.assertTrue(tx_obj.verify_input(input_index))
+        self.assertTrue(tx_obj.verify())
+
+    def test_musig(self):
+        hd_priv_key = HDPrivateKey.from_mnemonic(
+            "oil oil oil oil oil oil oil oil oil oil oil oil", network="signet"
+        )
+        # create a 3-of-5 multi-leaf musig
+        private_keys = []
+        for i in range(5):
+            private_keys.append(hd_priv_key.get_p2tr_receiving_privkey(address=i))
+        points = [priv.point for priv in private_keys]
+        tr_multisig = TapRootMultiSig(points, 3)
+        musig = MuSigTapScript(points)
+        tap_root = tr_multisig.musig_tap_root()
+        self.assertEqual(tr_multisig.default_internal_pubkey, musig.point)
+        prev_tx = bytes.fromhex(
+            "aab3619891f8de651dcbd18ed897017ade7bf8eda89202ba56a7b0403c54c511"
+        )
+        self.assertEqual(
+            tap_root.address(network="signet"),
+            "tb1pt8sygq8v5zjzrt03lwatrwm4vzvy3fktuhpv6hyhd63euw774vxq9u0vhn",
+        )
+        tx_ins = []
+        for prev_index in range(10):
+            tx_in = TxIn(prev_tx, prev_index)
+            tx_in._value = 998730
+            tx_in._script_pubkey = tap_root.script_pubkey()
+            tx_ins.append(tx_in)
+        tx_out = TxOut((tx_in.value() - 150), tap_root.script_pubkey())
+        tx_obj = Tx(1, tx_ins, [tx_out] * 10, 0, network="signet", segwit=True)
+        for input_index, pubkeys in enumerate(combinations(points, 3)):
+            tx_in = tx_obj.tx_ins[input_index]
+            musig = MuSigTapScript(pubkeys)
+            leaf = musig.tap_leaf()
+            cb = tap_root.control_block(leaf)
+            self.assertTrue(cb)
+            tx_in.witness.items = [leaf.tap_script.raw_serialize(), cb.serialize()]
+            sig_hash = tx_obj.sig_hash(input_index, SIGHASH_DEFAULT)
+            ks = [randint(1, N) for _ in pubkeys]
+            r = S256Point.combine([k_i * G for k_i in ks])
+            s_sum = 0
+            for priv in private_keys:
+                if priv.point in pubkeys:
+                    k_i = ks.pop()
+                    s_sum += musig.sign(priv, k_i, r, sig_hash)
+            schnorr = musig.get_signature(s_sum, r, sig_hash)
+            self.assertTrue(musig.point.verify_schnorr(sig_hash, schnorr))
+            tx_in.witness.items.insert(0, schnorr.serialize())
+            self.assertTrue(tx_obj.verify_input(input_index))
+        self.assertTrue(tx_obj.verify())
+
+    def test_internal_pubkey_musig(self):
+        hd_priv_key = HDPrivateKey.from_mnemonic(
+            "oil oil oil oil oil oil oil oil oil oil oil oil", network="signet"
+        )
+        # create a 3-of-5 multi-leaf musig
+        private_keys = []
+        for i in range(5):
+            private_keys.append(hd_priv_key.get_p2tr_receiving_privkey(address=i))
+        points = [priv.point for priv in private_keys]
+        tr_multisig = TapRootMultiSig(points, 3)
+        musig = MuSigTapScript(points)
+        tap_root_input = tr_multisig.musig_tap_root()
+        tap_root_output = tr_multisig.musig_and_single_leaf_tap_root()
+        self.assertEqual(tr_multisig.default_internal_pubkey, musig.point)
+        prev_tx = bytes.fromhex(
+            "d5b2a411f70a68fad8adb5362149aca04c213f0e195b7b2b4a7f4f905fbcce11"
+        )
+        tx_ins = []
+        for prev_index in range(10):
+            tx_in = TxIn(prev_tx, prev_index)
+            tx_in._value = 998580
+            tx_in._script_pubkey = tap_root_input.script_pubkey()
+            tx_ins.append(tx_in)
+        tx_out = TxOut((tx_in.value() - 102), tap_root_output.script_pubkey())
+        tx_obj = Tx(1, tx_ins, [tx_out] * 10, 0, network="signet", segwit=True)
+        for input_index, tx_in in enumerate(tx_ins):
+            ks = [randint(1, N) for _ in points]
+            r = S256Point.combine([k_i * G for k_i in ks])
+            s_sum = 0
+            sig_hash = tx_obj.sig_hash(input_index, SIGHASH_DEFAULT)
+            for priv in private_keys:
+                k_i = ks.pop()
+                s_sum += musig.sign(priv, k_i, r, sig_hash, tweak=tap_root_input.tweak)
+            schnorr = musig.get_signature(s_sum, r, sig_hash, tap_root_input.tweak)
+            tx_in.witness = Witness([schnorr.serialize()])
+            self.assertTrue(tx_obj.verify_input(input_index))
+        self.assertTrue(tx_obj.verify())
+
+    def test_musig_and_single_leaf_multisig(self):
+        hd_priv_key = HDPrivateKey.from_mnemonic(
+            "oil oil oil oil oil oil oil oil oil oil oil oil", network="signet"
+        )
+        # create a 3-of-5 single-leaf multisig
+        private_keys = [
+            hd_priv_key.get_p2tr_receiving_privkey(address=i) for i in range(5)
+        ]
+        points = [priv.point for priv in private_keys]
+        tr_multisig = TapRootMultiSig(points, 3)
+        tap_root_input = tr_multisig.musig_and_single_leaf_tap_root()
+        tap_root_output = tr_multisig.everything_tap_root()
+        leaf = tap_root_input.tap_node
+        prev_tx = bytes.fromhex(
+            "e6d03b31353c5bfcd2033db247d95909ed583e0d69d3bcbca9ddf31e98c861e4"
+        )
+        self.assertEqual(
+            tap_root_input.address(network="signet"),
+            "tb1pjzgcghtd0a0qxqwwl4c98assrvzsz647pkvvkty8r5pvz9ltndnq0adf09",
+        )
+        tx_ins = []
+        for prev_index in range(10):
+            tx_in = TxIn(prev_tx, prev_index)
+            tx_in._value = 998478
+            tx_in._script_pubkey = tap_root_input.script_pubkey()
+            tx_ins.append(tx_in)
+        tx_out = TxOut(tx_in.value() - 200, tap_root_output.script_pubkey())
+        tx_obj = Tx(1, tx_ins, [tx_out] * 10, 0, network="signet", segwit=True)
+        for input_index, pubkeys in enumerate(combinations(points, 3)):
+            tx_in = tx_obj.tx_ins[input_index]
+            if input_index & 1:
+                tx_in.witness.items = []
+                leaf = tr_multisig.single_leaf()
+                tx_obj.initialize_p2tr_multisig(
+                    input_index,
+                    tap_root_input.control_block(leaf),
+                    leaf.tap_script,
+                )
+                sigs = []
+                for priv in private_keys:
+                    if priv.point in pubkeys:
+                        sig = tx_obj.get_sig_taproot(input_index, priv, ext_flag=1)
+                    else:
+                        sig = b""
+                    sigs.append(sig)
+                tx_obj.finalize_p2tr_multisig(input_index, sigs)
+            else:
+                musig = MuSigTapScript(pubkeys)
+                leaf = musig.tap_leaf()
+                cb = tap_root_input.control_block(leaf)
+                self.assertTrue(cb)
+                tx_in.witness.items = [leaf.tap_script.raw_serialize(), cb.serialize()]
+                sig_hash = tx_obj.sig_hash(input_index, SIGHASH_DEFAULT)
+                ks = [randint(1, N) for _ in pubkeys]
+                r = S256Point.combine([k_i * G for k_i in ks])
+                s_sum = 0
+                for priv in private_keys:
+                    if priv.point in pubkeys:
+                        k_i = ks.pop()
+                        s_sum += musig.sign(priv, k_i, r, sig_hash)
+                schnorr = musig.get_signature(s_sum, r, sig_hash)
+                self.assertTrue(musig.point.verify_schnorr(sig_hash, schnorr))
+                tx_in.witness.items.insert(0, schnorr.serialize())
+            self.assertTrue(tx_obj.verify_input(input_index))
+        self.assertTrue(tx_obj.verify())
+
+    def test_everything_multisig(self):
+        hd_priv_key = HDPrivateKey.from_mnemonic(
+            "oil oil oil oil oil oil oil oil oil oil oil oil", network="signet"
+        )
+        # create a 3-of-5 single-leaf multisig
+        private_keys = [
+            hd_priv_key.get_p2tr_receiving_privkey(address=i) for i in range(5)
+        ]
+        points = [priv.point for priv in private_keys]
+        tr_multisig = TapRootMultiSig(points, 3)
+        tap_root_input = tr_multisig.everything_tap_root()
+        tap_root_output = tr_multisig.everything_tap_root()
+        leaf = tap_root_input.tap_node
+        prev_tx = bytes.fromhex(
+            "d99d760498dfac4fdfce89bd81264614f1eec84ca9246c69e2a90e2be36ae5fa"
+        )
+        self.assertEqual(
+            tap_root_input.address(network="signet"),
+            "tb1pyn9z7vueyftuglrsfwgsgajmwnp08x3hjfefnkclx7220fq7mxgq2hy8xp",
+        )
+        tx_ins = []
+        for prev_index in range(30):
+            tx_in = TxIn(prev_tx, prev_index)
+            tx_in._value = 332667
+            tx_in._script_pubkey = tap_root_input.script_pubkey()
+            tx_ins.append(tx_in)
+        tx_out = TxOut((tx_in.value() - 200), tap_root_output.script_pubkey())
+        tx_obj = Tx(1, tx_ins, [tx_out] * 30, 0, network="signet", segwit=True)
+        for input_index, pubkeys in enumerate(combinations(points, 3)):
+            tx_in = tx_obj.tx_ins[input_index]
+            tx_in.witness.items = []
+            leaf = tr_multisig.single_leaf()
+            tx_obj.initialize_p2tr_multisig(
+                input_index,
+                tap_root_input.control_block(leaf),
+                leaf.tap_script,
+            )
+            sigs = []
+            for priv in private_keys:
+                if priv.point in pubkeys:
+                    sig = tx_obj.get_sig_taproot(input_index, priv, ext_flag=1)
+                else:
+                    sig = b""
+                sigs.append(sig)
+            tx_obj.finalize_p2tr_multisig(input_index, sigs)
+            self.assertTrue(tx_obj.verify_input(input_index))
+        for i, pubkeys in enumerate(combinations(points, 3)):
+            input_index = i + 10
+            tx_in = tx_obj.tx_ins[input_index]
+            tx_in.witness.items = []
+            leaf = MultiSigTapScript(pubkeys, 3).tap_leaf()
+            self.assertTrue(tap_root_input.control_block(leaf))
+            tx_obj.initialize_p2tr_multisig(
+                input_index, tap_root_input.control_block(leaf), leaf.tap_script
+            )
+            sigs = []
+            for priv in private_keys:
+                if priv.point in pubkeys:
+                    sig = tx_obj.get_sig_taproot(input_index, priv, ext_flag=1)
+                    sigs.append(sig)
+            tx_obj.finalize_p2tr_multisig(input_index, sigs)
+            self.assertTrue(tx_obj.verify_input(input_index))
+        for i, pubkeys in enumerate(combinations(points, 3)):
+            input_index = i + 20
+            tx_in = tx_obj.tx_ins[input_index]
+            musig = MuSigTapScript(pubkeys)
+            leaf = musig.tap_leaf()
+            cb = tap_root_input.control_block(leaf)
+            self.assertTrue(cb)
+            tx_in.witness.items = [leaf.tap_script.raw_serialize(), cb.serialize()]
+            sig_hash = tx_obj.sig_hash(input_index, SIGHASH_DEFAULT)
+            ks = [randint(1, N) for _ in pubkeys]
+            r = S256Point.combine([k_i * G for k_i in ks])
+            s_sum = 0
+            for priv in private_keys:
+                if priv.point in pubkeys:
+                    k_i = ks.pop()
+                    s_sum += musig.sign(priv, k_i, r, sig_hash)
+            schnorr = musig.get_signature(s_sum, r, sig_hash)
+            self.assertTrue(musig.point.verify_schnorr(sig_hash, schnorr))
+            tx_in.witness.items.insert(0, schnorr.serialize())
+            self.assertTrue(tx_obj.verify_input(input_index))
+        self.assertTrue(tx_obj.verify())

--- a/buidl/test/test_taproot.py
+++ b/buidl/test/test_taproot.py
@@ -281,7 +281,7 @@ class TaprootTest(TestCase):
                 tap_script = Script.parse(
                     BytesIO(encode_varstr(bytes.fromhex(item["script"])))
                 )
-                tap_leaf = TapLeaf(tapleaf_version, tap_script)
+                tap_leaf = TapLeaf(tap_script, tapleaf_version)
                 return tap_leaf
             else:
                 return TapBranch(parse_item(item[0]), parse_item(item[1]))

--- a/buidl/witness.py
+++ b/buidl/witness.py
@@ -17,7 +17,10 @@ class Witness:
     def __repr__(self):
         result = ""
         for item in self.items:
-            result += "{} ".format(item.hex())
+            if item == b"":
+                result += "<null> "
+            else:
+                result += "{} ".format(item.hex())
         return result
 
     def __getitem__(self, key):
@@ -56,7 +59,7 @@ class Witness:
 
     def tap_leaf(self):
         leaf_version = self.control_block().tapleaf_version
-        return TapLeaf(leaf_version, self.tap_script())
+        return TapLeaf(self.tap_script(), leaf_version)
 
     @classmethod
     def parse(cls, s):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="buidl",
-    version="0.2.31",
+    version="0.2.32",
     author="Example Author",
     author_email="author@example.com",
     description="An easy-to-use and fully featured bitcoin library written in pure python (no dependencies).",


### PR DESCRIPTION
This module lets you do multisig three different ways:

Simple: Almost identical to the traditional OP_CHECKMULTISIG, but using OP_CHECKSIGADD as the only scriptspend

Multisig: If you have k-of-n, it makes c(k,n) leaves where c is the combinatoric function and each leaf is k-of-k multisig using OP_CHECKSIGADD

Musig: Like multisig, but instead of k-of-k multisig, uses MuSig to combine the keys. s's can be generated using the `sign` method in `MuSigTapScript`. They then have to get combined in `get_signature` to produce the signature.

The default internal pubkey for all three is the Musig combination of all n keys.