### PR TITLE
remove m1 ARM note

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Use [brew](https://brew.sh/) to install `libsecp256k1`:
 ```
 $ brew tap buidl-bitcoin/homebrew-libsecp256k1
 $ brew install pkg-config libffi libsecp256k1
-If you run into Homebrew installation issues with an M1 chip on MacOS [this SO post](https://stackoverflow.com/questions/64963370/error-cannot-install-in-homebrew-on-arm-processor-in-intel-default-prefix-usr) may be helpful.
 ```
 
 #### Hard (Linux/Mac)


### PR DESCRIPTION
This solved my problem previously, but actually it's the incorrect solution. A fresh m1 install of homebrew (vs migrating an x86 HD to an m1 machine) obsoletes this section.

(And the formatting was previously broken anyway).