### PR TITLE
WIP: fix p2sh redeemscript parsing

### DIFF
--- a/buidl/script.py
+++ b/buidl/script.py
@@ -105,7 +105,7 @@ class Script:
                 commands.append(op_code)
         obj = cls(commands)
         if count != length:
-            # FIXME: shouldn't this throw an error?
+            # Would throw error, but Bitcoin Core will read the number of bytes that are there (not what was promised)
             print(f"mismatch between length and consumed bytes {count} vs {length}")
             obj.raw = raw
         return obj

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="buidl",
-    version="0.2.34",
+    version="0.2.35",
     author="Example Author",
     author_email="author@example.com",
     description="An easy-to-use and fully featured bitcoin library written in pure python (no dependencies).",


### PR DESCRIPTION
This PR makes it possible to accurately `parse()` a p2sh redeemscript, but you have to opt into the new `parse_hex()` method.

It's the fewest lines of code to make this change, but it feels a little hackey. Also, moving the existing codebase over to use the new parsing logic will throw a ton of errors.

Any thoughts @jimmysong @dhruvbansal?

This is a proposed fix for https://github.com/buidl-bitcoin/buidl-python/issues/123