### PR TITLE
None for witness_lookup bad for PSBT.create()

### DIFF
--- a/buidl/psbt_helper.py
+++ b/buidl/psbt_helper.py
@@ -221,6 +221,6 @@ def create_multisig_psbt(
         tx_lookup=tx_lookup,
         pubkey_lookup=pubkey_lookup,
         redeem_lookup=redeem_lookup,
-        witness_lookup=None,
+        witness_lookup={},
         hd_pubs=hd_pubs,
     )


### PR DESCRIPTION
Passing in None to the witness_lookup in psbt_helper::create_multisig_psbt
does the wrong thing if you end up passing in a P2WSH address as an output.
It seems that an empty dictionary behaves correctly as an empty
witness_lookup object.