### PR TITLE
Possible Minor Docstring Typo in HDPublicKey.child()

### DIFF
--- a/buidl/hd.py
+++ b/buidl/hd.py
@@ -588,7 +588,7 @@ class HDPublicKey:
         return self.hash160()[:4]
 
     def child(self, index):
-        """Returns the child HDPrivateKey at a particular index.
+        """Returns the child HDPublicKey at a particular index.
         Raises ValueError for indices >= 0x8000000.
         """
         # if index >= 0x80000000, raise a ValueError


### PR DESCRIPTION
Possible minor typo.  Not functionality impacting.
HDPublicKey.child() returns an HDPublicKey object, but the function's docstring states  "Returns the child HDPrivateKey..."