### PR TITLE
Libsec update

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,6 @@ You can speed this library up ~100x by using C-bindings to [bitcoin core's `libs
 
 ### `libsecp256k1` Dependency Installation
 
-
-#### Easy (MacOS only)
-Use [brew](https://brew.sh/) to install `libsecp256k1`:
-```
-$ brew tap buidl-bitcoin/homebrew-libsecp256k1
-$ brew install pkg-config libffi libsecp256k1
-```
-
-#### Hard (Linux/Mac)
 Compile `libsecp256k1` from scratch with experimental modules enabled to make Schnorr signatures work:
 ```bash
 $ git clone https://github.com/bitcoin-core/secp256k1
@@ -97,6 +88,6 @@ $ sudo make install
 ### `buidl` Installation
 
 ```bash
-$ git clone git@github.com:buidl-bitcoin/buidl-python.git && cd buidl-python && python3 -m pip install -r requirements-libsec.txt && python3 -m pip install --editable . && cd buidl && python3 libsec_build.py && cd .. && python3 -c "from buidl import *; print('success') if is_libsec_enabled() else print('LIBSEC INSTALL FAIL')"
+$ git clone git@github.com:buidl-bitcoin/buidl-python.git && cd buidl-python && python3 -m pip install -r requirements-libsec.txt && python3 -m pip install --editable . && cd buidl && CPATH=/usr/local/include LIBRARY_PATH=/usr/local/lib python3 libsec_build.py && cd .. && python3 -c "from buidl import *; print('success') if is_libsec_enabled() else print('LIBSEC INSTALL FAIL')"
 
 ```

--- a/buidl/cecc.py
+++ b/buidl/cecc.py
@@ -384,7 +384,7 @@ class PrivateKey:
         ):
             raise RuntimeError("libsecp256k1 keypair creation problem")
         raw_sig = ffi.new("unsigned char [64]")
-        if not lib.secp256k1_schnorrsig_sign(GLOBAL_CTX, raw_sig, msg, keypair, aux):
+        if not lib.secp256k1_schnorrsig_sign32(GLOBAL_CTX, raw_sig, msg, keypair, aux):
             raise RuntimeError("libsecp256k1 schnorr signing problem")
         return SchnorrSignature(bytes(ffi.buffer(raw_sig, 64)))
 

--- a/buidl/libsec.h
+++ b/buidl/libsec.h
@@ -132,7 +132,7 @@ int secp256k1_keypair_create(
     const unsigned char *seckey
 );
 
-int secp256k1_schnorrsig_sign(
+int secp256k1_schnorrsig_sign32(
     const secp256k1_context* ctx,
     unsigned char *sig64,
     const unsigned char *msg32,


### PR DESCRIPTION
Updated libsec function as one of them is now deprecated.
Also changed the README instructions as they were out of date.