### PR TITLE
Change taproot functions

### DIFF
--- a/buidl/blinding.py
+++ b/buidl/blinding.py
@@ -19,7 +19,7 @@ def secure_secret_path(depth=4):
         8: 248
         9: 279
     """
-    if type(depth) != int:
+    if not isinstance(depth, int):
         raise ValueError(f"depth must be an int: {depth}")
     if depth >= 32:
         raise ValueError(

--- a/buidl/cecc.py
+++ b/buidl/cecc.py
@@ -209,6 +209,7 @@ class S256Point:
         """Returns the p2tr Script object"""
         # avoid circular dependency
         from buidl.script import P2PKTapScript
+
         return P2PKTapScript(self)
 
     def address(self, compressed=True, network="mainnet"):

--- a/buidl/cecc.py
+++ b/buidl/cecc.py
@@ -2,6 +2,7 @@ import hashlib
 import hmac
 import secrets
 
+from buidl.hash import hash_taptweak
 from buidl.helper import (
     big_endian_to_int,
     encode_base58_checksum,
@@ -86,6 +87,12 @@ class S256Point:
             raise RuntimeError("libsecp256k1 serialize error")
         return self.__class__(usec=bytes(serialized))
 
+    def even_point(self):
+        if self.parity:
+            return -1 * self
+        else:
+            return self
+
     def verify(self, z, sig):
         msg = int_to_big_endian(z, 32)
         sig_data = sig.cdata()
@@ -147,19 +154,20 @@ class S256Point:
         return bytes(ffi.buffer(output32, 32))
 
     def tweak(self, merkle_root=b""):
-        """returns the tweak for use in p2tr if there's no script path"""
+        """returns the tweak for use in p2tr"""
         # take the hash_taptweak of the xonly and the merkle root
         tweak = hash_taptweak(self.xonly() + merkle_root)
         return tweak
 
-    def tweaked_key(self, merkle_root=b""):
-        """Creates the tweaked external key for a particular tweak."""
+    def tweaked_key(self, merkle_root=b"", tweak=None):
+        """Creates the tweaked external key for a particular merkle root/tweak."""
         # Get the tweak with the merkle root
-        tweak = self.tweak(merkle_root)
+        if tweak is None:
+            tweak = self.tweak(merkle_root)
         # t is the tweak interpreted as a big endian integer
         t = big_endian_to_int(tweak)
         # Q = P + tG
-        external_key = self + t
+        external_key = self.even_point() + t
         # return the external key
         return external_key
 
@@ -189,13 +197,13 @@ class S256Point:
         """Returns the RedeemScript for a p2sh-p2wpkh redemption"""
         return self.p2wpkh_script().redeem_script()
 
-    def p2tr_script(self):
+    def p2tr_script(self, merkle_root=b"", tweak=None):
         """Returns the p2tr Script object"""
+        external_pubkey = self.tweaked_key(merkle_root, tweak)
         # avoid circular dependency
         from buidl.script import P2TRScriptPubKey
 
-        external_pubkey = self.tweaked_key(merkle_root)
-        return P2TRScriptPubKey(self)
+        return P2TRScriptPubKey(external_pubkey)
 
     def p2pk_tap_script(self):
         """Returns the p2tr Script object"""
@@ -215,9 +223,9 @@ class S256Point:
         """Returns the p2sh-p2wpkh base58 address string"""
         return self.p2wpkh_script().p2sh_address(network)
 
-    def p2tr_address(self, network="mainnet"):
+    def p2tr_address(self, merkle_root=b"", tweak=None, network="mainnet"):
         """Returns the p2tr bech32m address string"""
-        return self.p2tr_script().address(network)
+        return self.p2tr_script(merkle_root, tweak).address(network)
 
     def verify_message(self, message, sig):
         """Verify a message in the form of bytes. Assumes that the z
@@ -365,6 +373,12 @@ class PrivateKey:
     def hex(self):
         return "{:x}".format(self.secret).zfill(64)
 
+    def even_secret(self):
+        if self.point.parity:
+            return N - self.secret
+        else:
+            return self.secret
+
     def sign(self, z):
         # per libsecp256k1 documentation, this helps against side-channel attacks
         if not lib.secp256k1_context_randomize(
@@ -452,12 +466,15 @@ class PrivateKey:
         # encode_base58_checksum the whole thing
         return encode_base58_checksum(prefix + secret_bytes + suffix)
 
-    def tweaked(self, tweak):
-        if self.point.parity:
-            s = N - self.secret
-        else:
-            s = self.secret
-        new_secret = (s + tweak) % N
+    def tweaked_key(self, merkle_root=b""):
+        e = self.even_secret()
+        # get the tweak from the point's tweak method
+        tweak = self.point.tweak(merkle_root)
+        # t is the tweak interpreted as big endian
+        t = big_endian_to_int(tweak)
+        # new secret is the secret plus t (make sure to mod by N)
+        new_secret = (e + t) % N
+        # create a new instance of this class using self.__class__
         return self.__class__(new_secret, network=self.network)
 
     @classmethod

--- a/buidl/compactfilter.py
+++ b/buidl/compactfilter.py
@@ -254,7 +254,6 @@ class CFHeadersMessage:
 
 
 class GetCFCheckPointMessage:
-
     command = b"getcfcheckpt"
     define_network = False
 

--- a/buidl/descriptor.py
+++ b/buidl/descriptor.py
@@ -151,7 +151,6 @@ def parse_any_key_record(key_record_str):
 
 
 class P2WSHSortedMulti:
-
     # TODO: make an inheritable base descriptor class that this inherits from
 
     def __init__(

--- a/buidl/ecc.py
+++ b/buidl/ecc.py
@@ -1,4 +1,5 @@
 try:
+    raise ModuleNotFoundError
     from buidl.cecc import *  # noqa: F401,F403
 except ModuleNotFoundError:
     from buidl.pecc import *  # noqa: F401,F403

--- a/buidl/ecc.py
+++ b/buidl/ecc.py
@@ -1,5 +1,4 @@
 try:
-    raise ModuleNotFoundError
     from buidl.cecc import *  # noqa: F401,F403
 except ModuleNotFoundError:
     from buidl.pecc import *  # noqa: F401,F403

--- a/buidl/hd.py
+++ b/buidl/hd.py
@@ -332,9 +332,8 @@ class HDPrivateKey:
         return hd_priv.private_key
 
     def _get_address(self, purpose, account_num=0, is_external=True, address_num=0):
-        """Returns the proper address among purposes 44', 49' and 84'.
-        p2pkh for 44', p2sh-p2wpkh for 49' and p2wpkh for 84'."""
-        # if purpose is not one of 44', 49' or 84', raise ValueError
+        """Returns the proper address among purposes 44', 49', 84' and 86'.
+        p2pkh for 44', p2sh-p2wpkh for 49', p2wpkh for 84', and p2tr for 86'."""
         point = self.get_private_key(
             purpose=purpose,
             account_num=account_num,
@@ -353,6 +352,7 @@ class HDPrivateKey:
         # if 86', return the p2tr_address
         elif purpose == "86'":
             return point.p2tr_address(network=self.network)
+        # if purpose is not one of 44', 49', 84' or 86', raise ValueError
         else:
             raise ValueError(
                 f"Cannot create an address without a proper purpose: {purpose}"

--- a/buidl/libsec_build.py
+++ b/buidl/libsec_build.py
@@ -13,5 +13,10 @@ header = """
 
 ffi = FFI()
 ffi.cdef(source)
-ffi.set_source("_libsec", header, libraries=["secp256k1"], include_dirs=["/opt/homebrew/Cellar/libsecp256k1/0.1/include"])
+ffi.set_source(
+    "_libsec",
+    header,
+    libraries=["secp256k1"],
+    include_dirs=["/opt/homebrew/Cellar/libsecp256k1/0.1/include"],
+)
 ffi.compile(verbose=True)

--- a/buidl/libsec_build.py
+++ b/buidl/libsec_build.py
@@ -13,5 +13,5 @@ header = """
 
 ffi = FFI()
 ffi.cdef(source)
-ffi.set_source("_libsec", header, libraries=["secp256k1"])
+ffi.set_source("_libsec", header, libraries=["secp256k1"], include_dirs=["/opt/homebrew/Cellar/libsecp256k1/0.1/include"])
 ffi.compile(verbose=True)

--- a/buidl/mnemonic.py
+++ b/buidl/mnemonic.py
@@ -21,7 +21,7 @@ def secure_mnemonic(num_bits=256, extra_entropy=0):
     """
     if num_bits not in (128, 160, 192, 224, 256):
         raise ValueError(f"Invalid num_bits: {num_bits}")
-    if type(extra_entropy) is not int:
+    if not isinstance(extra_entropy, int):
         raise TypeError(f"extra_entropy must be an int: {extra_entropy}")
     if extra_entropy < 0:
         raise ValueError(f"extra_entropy cannot be negative: {extra_entropy}")
@@ -115,9 +115,9 @@ class WordList:
                 self.lookup[word[:4]] = i
 
     def __getitem__(self, key):
-        if type(key) == str:
+        if isinstance(key, str):
             return self.lookup[key]
-        elif type(key) == int:
+        elif isinstance(key, int):
             return self.words[key]
         else:
             raise KeyError("key needs to be a str or int")

--- a/buidl/op.py
+++ b/buidl/op.py
@@ -748,7 +748,7 @@ def op_checksig_schnorr(stack, tx_obj, input_index):
         return False
     pubkey = stack.pop()
     signature = stack.pop()
-    point = S256Point.parse_bip340(pubkey)
+    point = S256Point.parse_xonly(pubkey)
     if len(signature) == 65:
         hash_type = signature[-1]
         signature = signature[:-1]
@@ -777,7 +777,7 @@ def op_checksigadd_schnorr(stack, tx_obj, input_index):
     pubkey = stack.pop()
     n = decode_num(stack.pop())
     signature = stack.pop()
-    point = S256Point.parse_bip340(pubkey)
+    point = S256Point.parse_xonly(pubkey)
     if len(signature) == 65:
         hash_type = signature[-1]
         signature = signature[:-1]

--- a/buidl/pecc.py
+++ b/buidl/pecc.py
@@ -217,7 +217,7 @@ class S256Field(FieldElement):
 class S256Point(Point):
     def __init__(self, x, y, a=None, b=None):
         a, b = S256Field(A), S256Field(B)
-        if type(x) == int:
+        if isinstance(x, int):
             super().__init__(x=S256Field(x), y=S256Field(y), a=a, b=b)
         else:
             super().__init__(x=x, y=y, a=a, b=b)
@@ -244,7 +244,7 @@ class S256Point(Point):
 
     def __add__(self, other):
         """If other is an int, multiplies scalar by generator, adds result to current point"""
-        if type(other) == int:
+        if isinstance(other, int):
             return super().__add__(other * G)
         else:
             return super().__add__(other)

--- a/buidl/psbt.py
+++ b/buidl/psbt.py
@@ -665,7 +665,6 @@ Extra:\n{self.extra_map}
                 raise ValueError(f"xfp_hex {xfp_to_hide} not found in psbt")
 
     def _describe_basic_multisig_inputs(self, hdpubkey_map):
-
         # These will be used for all inputs and change outputs
         inputs_quorum_m, inputs_quorum_n = None, None
 
@@ -791,7 +790,6 @@ Extra:\n{self.extra_map}
         expected_quorum_n,
         hdpubkey_map={},
     ):
-
         # intialize variable we'll loop through to set
         outputs_desc = []
         spend_addr, spend_sats = "", 0
@@ -1608,7 +1606,7 @@ Witness:\n{self.witness}
             # for each command in the RedeemScript
             for command in self.redeem_script.commands:
                 # skip if the command is an integer
-                if type(command) == int:
+                if isinstance(command, int):
                     continue
                 # grab the sig for the pubkey
                 sig = self.sigs.get(command)

--- a/buidl/psbt_helper.py
+++ b/buidl/psbt_helper.py
@@ -80,7 +80,6 @@ def create_multisig_psbt(
 
     tx_ins, total_input_sats = [], 0
     for cnt, input_dict in enumerate(input_dicts):
-
         # Prev tx stuff
         prev_tx_dict = input_dict["prev_tx_dict"]
         prev_tx_obj = Tx.parse_hex(prev_tx_dict["hex"], network=network)

--- a/buidl/script.py
+++ b/buidl/script.py
@@ -37,7 +37,7 @@ class Script:
     def __repr__(self):
         result = ""
         for command in self.commands:
-            if type(command) == int:
+            if isinstance(command, int):
                 if OP_CODE_NAMES.get(command):
                     name = OP_CODE_NAMES.get(command)
                 else:
@@ -123,7 +123,7 @@ class Script:
         # go through each command
         for command in self.commands:
             # if the command is an integer, it's an op code
-            if type(command) == int:
+            if isinstance(command, int):
                 # turn the command into a single byte integer using int_to_byte
                 result += int_to_byte(command)
             else:
@@ -166,7 +166,7 @@ class Script:
         op_lookup = OP_CODE_FUNCTIONS
         while len(commands) > 0:
             command = commands.pop(0)
-            if type(command) == int:
+            if isinstance(command, int):
                 # do what the op code says
                 operation = op_lookup[command]
                 if command in (99, 100):
@@ -198,7 +198,7 @@ class Script:
                 if (
                     len(commands) == 3
                     and commands[0] == 0xA9
-                    and type(commands[1]) == bytes
+                    and isinstance(commands[1], bytes)
                     and len(commands[1]) == 20
                     and commands[2] == 0x87
                 ):
@@ -290,7 +290,7 @@ class Script:
             len(self.commands) == 5
             and self.commands[0] == 0x76
             and self.commands[1] == 0xA9
-            and type(self.commands[2]) == bytes
+            and isinstance(self.commands[2], bytes)
             and len(self.commands[2]) == 20
             and self.commands[3] == 0x88
             and self.commands[4] == 0xAC
@@ -304,7 +304,7 @@ class Script:
         return (
             len(self.commands) == 3
             and self.commands[0] == 0xA9
-            and type(self.commands[1]) == bytes
+            and isinstance(self.commands[1], bytes)
             and len(self.commands[1]) == 20
             and self.commands[2] == 0x87
         )
@@ -315,7 +315,7 @@ class Script:
         return (
             len(self.commands) == 2
             and self.commands[0] == 0x00
-            and type(self.commands[1]) == bytes
+            and isinstance(self.commands[1], bytes)
             and len(self.commands[1]) == 20
         )
 
@@ -325,7 +325,7 @@ class Script:
         return (
             len(self.commands) == 2
             and self.commands[0] == 0x00
-            and type(self.commands[1]) == bytes
+            and isinstance(self.commands[1], bytes)
             and len(self.commands[1]) == 32
         )
 
@@ -335,7 +335,7 @@ class Script:
         return (
             len(self.commands) == 2
             and self.commands[0] == 0x51
-            and type(self.commands[1]) == bytes
+            and isinstance(self.commands[1], bytes)
             and len(self.commands[1]) == 32
         )
 
@@ -376,7 +376,7 @@ class ScriptPubKey(Script):
 class P2PKHScriptPubKey(ScriptPubKey):
     def __init__(self, h160):
         super().__init__()
-        if type(h160) != bytes:
+        if not isinstance(h160, bytes):
             raise TypeError("To initialize P2PKHScriptPubKey, a hash160 is needed")
         self.commands = [0x76, 0xA9, h160, 0x88, 0xAC]
 
@@ -395,7 +395,7 @@ class P2PKHScriptPubKey(ScriptPubKey):
 class P2SHScriptPubKey(ScriptPubKey):
     def __init__(self, h160):
         super().__init__()
-        if type(h160) != bytes:
+        if not isinstance(h160, bytes):
             raise TypeError("To initialize P2SHScriptPubKey, a hash160 is needed")
         self.commands = [0xA9, h160, 0x87]
 
@@ -516,7 +516,7 @@ class SegwitPubKey(ScriptPubKey):
 class P2WPKHScriptPubKey(SegwitPubKey):
     def __init__(self, h160):
         super().__init__()
-        if type(h160) != bytes:
+        if not isinstance(h160, bytes):
             raise TypeError("To initialize P2WPKHScriptPubKey, a hash160 is needed")
         self.commands = [0x00, h160]
 
@@ -524,7 +524,7 @@ class P2WPKHScriptPubKey(SegwitPubKey):
 class P2WSHScriptPubKey(SegwitPubKey):
     def __init__(self, s256):
         super().__init__()
-        if type(s256) != bytes:
+        if not isinstance(s256, bytes):
             raise TypeError("To initialize P2WSHScriptPubKey, a sha256 is needed")
         self.commands = [0x00, s256]
 
@@ -532,9 +532,9 @@ class P2WSHScriptPubKey(SegwitPubKey):
 class P2TRScriptPubKey(ScriptPubKey):
     def __init__(self, point):
         super().__init__()
-        if type(point) == S256Point:
+        if isinstance(point, S256Point):
             raw_point = point.xonly()
-        elif type(point) == bytes:
+        elif isinstance(point, bytes):
             raw_point = point
         else:
             raise TypeError(
@@ -586,8 +586,8 @@ class WitnessScript(Script):
     def is_p2wsh_multisig(self):
         return (
             OP_CODE_NAMES[self.commands[-1]] == "OP_CHECKMULTISIG"
-            and type(self.commands[0]) == int
-            and type(self.commands[-2]) == int
+            and isinstance(self.commands[0], int)
+            and isinstance(self.commands[-2], int)
         )
 
     def get_quorum(self):

--- a/buidl/script.py
+++ b/buidl/script.py
@@ -266,7 +266,7 @@ class Script:
                         if tweak_point.parity != control_block.parity:
                             print("bad tweak point parity")
                             return False
-                        if tweak_point.bip340() != stack.pop():
+                        if tweak_point.xonly() != stack.pop():
                             print("bad tweak point")
                             return False
                         # pop off the 1 and start fresh
@@ -533,7 +533,7 @@ class P2TRScriptPubKey(ScriptPubKey):
     def __init__(self, point):
         super().__init__()
         if type(point) == S256Point:
-            raw_point = point.bip340()
+            raw_point = point.xonly()
         elif type(point) == bytes:
             raw_point = point
         else:

--- a/buidl/script.py
+++ b/buidl/script.py
@@ -260,8 +260,8 @@ class Script:
                     elif len(witness) > 1:
                         # this is a script path spend
                         control_block = witness.control_block()
-                        tap_leaf = witness.tap_leaf()
-                        tweak_point = control_block.tweak_point(tap_leaf)
+                        tap_script = witness.tap_script()
+                        tweak_point = control_block.external_pubkey(tap_script)
                         # the tweak point should be what's on the stack
                         if tweak_point.parity != control_block.parity:
                             print("bad tweak point parity")

--- a/buidl/shamir.py
+++ b/buidl/shamir.py
@@ -339,7 +339,8 @@ class ShareSet:
     @classmethod
     def generate_shares(cls, mnemonic, k, n, passphrase=b"", exponent=0):
         """Takes a BIP39 mnemonic along with k, n, passphrase and exponent.
-        Returns a list of SLIP39 mnemonics, any k of of which, along with the passphrase, recover the secret"""
+        Returns a list of SLIP39 mnemonics, any k of of which, along with the passphrase, recover the secret
+        """
         # convert mnemonic to a shared secret
         secret = mnemonic_to_bytes(mnemonic)
         num_bits = len(secret) * 8

--- a/buidl/taproot.py
+++ b/buidl/taproot.py
@@ -9,7 +9,6 @@ from buidl.hash import (
     hash_musignonce,
     hash_tapbranch,
     hash_tapleaf,
-    hash_taptweak,
 )
 from buidl.helper import (
     big_endian_to_int,
@@ -20,7 +19,7 @@ from buidl.op import (
     encode_minimal_num,
     number_to_op_code,
 )
-from buidl.script import Script, ScriptPubKey, P2TRScriptPubKey
+from buidl.script import Script, ScriptPubKey
 from buidl.timelock import Locktime, Sequence
 
 
@@ -48,7 +47,7 @@ class TapLeaf:
 
     def __eq__(self, other):
         return (
-            type(self) == type(other)
+            type(self) is type(other)
             and self.tapleaf_version == other.tapleaf_version
             and self.tap_script == other.tap_script
         )

--- a/buidl/test/test_ecc.py
+++ b/buidl/test/test_ecc.py
@@ -220,7 +220,7 @@ class PrivateKeyTest(TestCase):
         if r.parity:
             k = N - k
             r = k * G
-        message = r.bip340() + tweak_point.bip340() + msg
+        message = r.xonly() + tweak_point.xonly() + msg
         challenge = big_endian_to_int(hash_challenge(message)) % N
         if pk.point.parity == tweak_point.parity:
             secret = pk.secret
@@ -231,5 +231,5 @@ class PrivateKeyTest(TestCase):
             s = (s - challenge * tweak) % N
         else:
             s = (s + challenge * tweak) % N
-        sig = SchnorrSignature.parse(r.bip340() + int_to_big_endian(s, 32))
+        sig = SchnorrSignature.parse(r.xonly() + int_to_big_endian(s, 32))
         self.assertTrue(tweak_point.verify_schnorr(msg, sig))

--- a/buidl/test/test_ecc.py
+++ b/buidl/test/test_ecc.py
@@ -8,7 +8,6 @@ from buidl.hash import hash_challenge
 from buidl.helper import big_endian_to_int, int_to_big_endian
 
 
-
 class S256Test(TestCase):
     def test_pubpoint(self):
         # write a test that tests the public point for the following

--- a/buidl/test/test_musig.py
+++ b/buidl/test/test_musig.py
@@ -1,9 +1,9 @@
 from itertools import combinations
 from unittest import TestCase
 
-from buidl.ecc import S256Point, N, SchnorrSignature
+from buidl.ecc import S256Point
 from buidl.hd import HDPrivateKey
-from buidl.helper import SIGHASH_DEFAULT, big_endian_to_int, int_to_big_endian
+from buidl.helper import SIGHASH_DEFAULT
 from buidl.script import address_to_script_pubkey
 from buidl.taproot import MultiSigTapScript, MuSigTapScript, TapRootMultiSig
 from buidl.timelock import Locktime, Sequence
@@ -439,7 +439,9 @@ class MuSigTest(TestCase):
             leaf = MultiSigTapScript(pubkeys, 3).tap_leaf()
             self.assertTrue(branch.control_block(internal_pubkey, leaf))
             tx_obj.initialize_p2tr_multisig(
-                input_index, branch.control_block(internal_pubkey, leaf), leaf.tap_script
+                input_index,
+                branch.control_block(internal_pubkey, leaf),
+                leaf.tap_script,
             )
             sigs = []
             for priv in private_keys:
@@ -1162,7 +1164,9 @@ class MuSigTest(TestCase):
             leaf = MultiSigTapScript(pubkeys, 3).tap_leaf()
             self.assertTrue(branch.control_block(internal_pubkey, leaf))
             tx_obj.initialize_p2tr_multisig(
-                input_index, branch.control_block(internal_pubkey, leaf), leaf.tap_script
+                input_index,
+                branch.control_block(internal_pubkey, leaf),
+                leaf.tap_script,
             )
             sigs = []
             for priv in private_keys:
@@ -1230,9 +1234,7 @@ class MuSigTest(TestCase):
         ]
         points = [priv.point for priv in private_keys]
         tr_multisig = TapRootMultiSig(points, 3)
-        branch = tr_multisig.degrading_multisig_tree(
-            sequence_time_interval=18 * 512
-        )
+        branch = tr_multisig.degrading_multisig_tree(sequence_time_interval=18 * 512)
         merkle_root = branch.hash()
         internal_pubkey = tr_multisig.default_internal_pubkey
         self.assertEqual(
@@ -1394,9 +1396,7 @@ class MuSigTest(TestCase):
         ]
         points = [priv.point for priv in private_keys]
         tr_multisig = TapRootMultiSig(points, 3)
-        branch = tr_multisig.degrading_multisig_tree(
-            sequence_block_interval=18
-        )
+        branch = tr_multisig.degrading_multisig_tree(sequence_block_interval=18)
         merkle_root = branch.hash()
         internal_pubkey = tr_multisig.default_internal_pubkey
         self.assertEqual(

--- a/buidl/test/test_musig.py
+++ b/buidl/test/test_musig.py
@@ -89,7 +89,7 @@ class MuSigTest(TestCase):
             self.assertEqual(nonce_sums[1], r_2_sum)
             self.assertEqual(musig.compute_coefficient(nonce_sums, msg), test[-2])
             r = musig.compute_r(nonce_sums, msg)
-            self.assertEqual(r.bip340().hex(), want)
+            self.assertEqual(r.xonly().hex(), want)
 
     def test_musig2_point_aggregation(self):
         tests = [
@@ -144,9 +144,9 @@ class MuSigTest(TestCase):
         ]
         for test in tests:
             want = bytes.fromhex(test[-1])
-            points = [S256Point.parse_bip340(bytes.fromhex(h)) for h in test[:-1]]
+            points = [S256Point.parse_xonly(bytes.fromhex(h)) for h in test[:-1]]
             tap_script = MuSigTapScript(points)
-            self.assertEqual(tap_script.point.bip340(), want)
+            self.assertEqual(tap_script.point.xonly(), want)
 
     def test_single_leaf_multisig(self):
         hd_priv_key = HDPrivateKey.from_mnemonic(

--- a/buidl/test/test_psbt_helper.py
+++ b/buidl/test/test_psbt_helper.py
@@ -39,7 +39,6 @@ class P2SHTest(TestCase):
         # https://blockstream.info/testnet/tx/4412d2a7664d01bb784a0a359e9aacf160ee436067c6a42dca355da4817ca7da
 
     def test_sweep_1of2_p2sh(self):
-
         # This test will produce a validly signed TX for the 1-of-2 p2sh using either key, which will result in a different TX ID
         # d8172be9981a4f57e6e4ebe0f4785f5f2035aee40ffbb2d6f1200810a879d490 is the one that was broadcast to the testnet blockchain:
         # https://blockstream.info/testnet/tx/d8172be9981a4f57e6e4ebe0f4785f5f2035aee40ffbb2d6f1200810a879d490
@@ -108,7 +107,6 @@ class P2SHTest(TestCase):
 
             root_path_to_use = None
             for cnt, psbt_in in enumerate(psbt_obj.psbt_ins):
-
                 self.assertEqual(psbt_in.redeem_script.get_quorum(), (1, 2))
 
                 # For this TX there is only one psbt_in (1 input)
@@ -140,7 +138,6 @@ class P2SHTest(TestCase):
         create_multisig_psbt(**kwargs, script_type="p2sh")
 
     def test_sweep_1of2_p2sh_with_non_BIP67_input(self):
-
         # This test will produce a validly signed TX for the 1-of-2 p2sh using either key, which will result in a different TX ID
         # d8172be9981a4f57e6e4ebe0f4785f5f2035aee40ffbb2d6f1200810a879d490 is the one that was broadcast to the testnet blockchain:
         # https://blockstream.info/testnet/tx/d8172be9981a4f57e6e4ebe0f4785f5f2035aee40ffbb2d6f1200810a879d490
@@ -209,7 +206,6 @@ class P2SHTest(TestCase):
 
             root_path_to_use = None
             for cnt, psbt_in in enumerate(psbt_obj.psbt_ins):
-
                 self.assertEqual(psbt_in.redeem_script.get_quorum(), (1, 2))
 
                 # For this TX there is only one psbt_in (1 input)
@@ -233,7 +229,6 @@ class P2SHTest(TestCase):
             self.assertEqual(psbt_obj.final_tx().hash().hex(), signed_tx_hash_hex)
 
     def test_spend_1of2_with_change(self):
-
         kwargs = {
             # this part is unchanged from the previous
             "public_key_records": [
@@ -316,7 +311,6 @@ class P2SHTest(TestCase):
 
             root_path_to_use = None
             for cnt, psbt_in in enumerate(psbt_obj.psbt_ins):
-
                 self.assertEqual(psbt_in.redeem_script.get_quorum(), (1, 2))
 
                 # For this TX there is only one psbt_in (1 input)
@@ -579,7 +573,6 @@ class P2SHTest(TestCase):
             psbt_desc_want,
             expected_tx_hash,
         ) in test_outputs:
-
             # Return all the funds to the faucet address
             psbt_obj = create_multisig_psbt(
                 public_key_records=pubkey_records,

--- a/buidl/test/test_schnorr.py
+++ b/buidl/test/test_schnorr.py
@@ -46,14 +46,14 @@ class SchnorrTest(TestCase):
         for (
             index,
             secret,
-            bip340_pk,
+            xonly_pk,
             aux_rand,
             message,
             signature,
             comment,
         ) in tests:
             private_key = PrivateKey(secret=int(secret, 16))
-            public_key = S256Point.parse(bytes.fromhex(bip340_pk))
+            public_key = S256Point.parse(bytes.fromhex(xonly_pk))
             aux = bytes.fromhex(aux_rand)
             msg = bytes.fromhex(message)
             want_sig = SchnorrSignature.parse(bytes.fromhex(signature))
@@ -74,8 +74,8 @@ class SchnorrTest(TestCase):
                 "23b1d4ff27b16af4b0fcb9672df671701a1a7f5a6bb7352b051f461edbc614aa6068b3e5313a174f90f3d95dc4e06f69bebd9cf5a3098fde034b01e69e8e7889",
             ),
         ]
-        for bip340_pk, message, signature in tests:
-            public_key = S256Point.parse(bytes.fromhex(bip340_pk))
+        for xonly_pk, message, signature in tests:
+            public_key = S256Point.parse(bytes.fromhex(xonly_pk))
             msg = bytes.fromhex(message)
             sig = SchnorrSignature.parse(bytes.fromhex(signature))
             self.assertTrue(public_key.verify_schnorr(msg, sig))
@@ -153,10 +153,10 @@ class SchnorrTest(TestCase):
                 "public key is not a valid X coordinate because it exceeds the field size",
             ),
         ]
-        for bip340_pk, message, signature, error, comment in tests:
+        for xonly_pk, message, signature, error, comment in tests:
             with self.assertRaises(error):
                 print(comment)
-                public_key = S256Point.parse(bytes.fromhex(bip340_pk))
+                public_key = S256Point.parse(bytes.fromhex(xonly_pk))
                 msg = bytes.fromhex(message)
                 sig = SchnorrSignature.parse(bytes.fromhex(signature))
                 assert public_key.verify_schnorr(msg, sig)

--- a/buidl/test/test_script.py
+++ b/buidl/test/test_script.py
@@ -197,7 +197,6 @@ class WitnessScriptTest(TestCase):
         self.assertEqual(witness_script.p2sh_address(network="signet"), want)
 
     def test_p2wsh_with_quorum(self):
-
         p2wsh_script_hex = "ad51210236a6cf4254c8290a168ecab4aee771018d357ea87154a5b5fea9ed9baee2585e210355ec1001c2c4f1dce2de940beacbdcb7d7746140281a9283000aa46d251d46312103833d6e7c4121180fb79180b78a0573ad57c299825f18f49f6942cb38b6bf023a2103a9e341c32d8870706115443cf163bfc3d2da0ca8515a29bcc1a500c65cfb23bb2103b2ac11803043c0db884dcddfdcff02599324d5e747b26e4235f57b8019fae04155ae"
         witness_script = WitnessScript.parse(BytesIO(bytes.fromhex((p2wsh_script_hex))))
 

--- a/buidl/test/test_taproot.py
+++ b/buidl/test/test_taproot.py
@@ -68,8 +68,12 @@ class TaprootTest(TestCase):
             external_pubkey = point.tweaked_key(tweak=raw_tweak)
             self.assertEqual(external_pubkey.xonly(), external_pubkey_want.xonly())
             script_pubkey_want = bytes.fromhex(test["expected"]["scriptPubKey"])
-            self.assertEqual(point.p2tr_script(tweak=raw_tweak).raw_serialize(), script_pubkey_want)
-            self.assertEqual(point.p2tr_address(tweak=raw_tweak), test["expected"]["bip350Address"])
+            self.assertEqual(
+                point.p2tr_script(tweak=raw_tweak).raw_serialize(), script_pubkey_want
+            )
+            self.assertEqual(
+                point.p2tr_address(tweak=raw_tweak), test["expected"]["bip350Address"]
+            )
 
     def test_p2tr_general(self):
         tests = [
@@ -272,7 +276,7 @@ class TaprootTest(TestCase):
         ]
 
         def parse_item(item):
-            if type(item) == dict:
+            if isinstance(item, dict):
                 tapleaf_version = item["leafVersion"]
                 tap_script = TapScript.parse(
                     BytesIO(encode_varstr(bytes.fromhex(item["script"])))
@@ -302,7 +306,9 @@ class TaprootTest(TestCase):
             )
             script_pubkey_want = ScriptPubKey.parse(stream)
             self.assertEqual(point.p2tr_script(merkle_root), script_pubkey_want)
-            self.assertEqual(point.p2tr_address(merkle_root), test["expected"]["bip350Address"])
+            self.assertEqual(
+                point.p2tr_address(merkle_root), test["expected"]["bip350Address"]
+            )
             control_blocks = test["expected"]["scriptPathControlBlocks"]
             leaf_hashes = test["intermediary"]["leafHashes"]
             for control_block_hex, tap_leaf, leaf_hash in zip(
@@ -318,8 +324,12 @@ class TaprootTest(TestCase):
                 )
                 self.assertEqual(control_block.serialize(), control_block_raw)
                 self.assertEqual(control_block.internal_pubkey, point)
-                self.assertEqual(control_block.merkle_root(tap_leaf.tap_script), merkle_root)
-                self.assertEqual(control_block.internal_pubkey.tweak(merkle_root), raw_tweak)
+                self.assertEqual(
+                    control_block.merkle_root(tap_leaf.tap_script), merkle_root
+                )
+                self.assertEqual(
+                    control_block.internal_pubkey.tweak(merkle_root), raw_tweak
+                )
 
     def test_p2tr_spending(self):
         test = {

--- a/buidl/test/test_taproot.py
+++ b/buidl/test/test_taproot.py
@@ -11,6 +11,7 @@ from buidl.taproot import (
     ControlBlock,
     TapLeaf,
     TapBranch,
+    TapScript,
 )
 from buidl.tx import Tx
 from buidl.witness import Witness
@@ -18,14 +19,13 @@ from buidl.witness import Witness
 
 class TaprootTest(TestCase):
     def test_hd(self):
-        point = S256Point.parse_bip340(
+        point = S256Point.parse_xonly(
             bytes.fromhex(
                 "cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115"
             )
         )
-        t = TapRoot(point)
         self.assertEqual(
-            t.tweak_point.xonly().hex(),
+            point.tweaked_key().xonly().hex(),
             "a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c",
         )
 
@@ -61,18 +61,15 @@ class TaprootTest(TestCase):
                 bytes.fromhex(test["given"]["internalPubkey"])
             )
             raw_tweak = bytes.fromhex(test["intermediary"]["tweak"])
-            tap_root = TapRoot(point)
-            self.assertEqual(tap_root.tweak, big_endian_to_int(raw_tweak))
-            tweak_point_want = S256Point.parse_xonly(
+            self.assertEqual(point.tweak(), raw_tweak)
+            external_pubkey_want = S256Point.parse_xonly(
                 bytes.fromhex(test["intermediary"]["tweakedPubkey"])
             )
-            self.assertEqual(tap_root.xonly(), tweak_point_want.xonly())
-            stream = BytesIO(
-                encode_varstr(bytes.fromhex(test["expected"]["scriptPubKey"]))
-            )
-            script_pubkey_want = ScriptPubKey.parse(stream)
-            self.assertEqual(tap_root.script_pubkey(), script_pubkey_want)
-            self.assertEqual(tap_root.address(), test["expected"]["bip350Address"])
+            external_pubkey = point.tweaked_key(tweak=raw_tweak)
+            self.assertEqual(external_pubkey.xonly(), external_pubkey_want.xonly())
+            script_pubkey_want = bytes.fromhex(test["expected"]["scriptPubKey"])
+            self.assertEqual(point.p2tr_script(tweak=raw_tweak).raw_serialize(), script_pubkey_want)
+            self.assertEqual(point.p2tr_address(tweak=raw_tweak), test["expected"]["bip350Address"])
 
     def test_p2tr_general(self):
         tests = [
@@ -277,7 +274,7 @@ class TaprootTest(TestCase):
         def parse_item(item):
             if type(item) == dict:
                 tapleaf_version = item["leafVersion"]
-                tap_script = Script.parse(
+                tap_script = TapScript.parse(
                     BytesIO(encode_varstr(bytes.fromhex(item["script"])))
                 )
                 tap_leaf = TapLeaf(tap_script, tapleaf_version)
@@ -293,19 +290,19 @@ class TaprootTest(TestCase):
             merkle_root = tap_tree.hash()
             merkle_root_want = bytes.fromhex(test["intermediary"]["merkleRoot"])
             self.assertEqual(merkle_root, merkle_root_want)
-            tap_root = TapRoot(point, tap_tree)
             raw_tweak = bytes.fromhex(test["intermediary"]["tweak"])
-            self.assertEqual(tap_root.tweak, big_endian_to_int(raw_tweak))
+            self.assertEqual(point.tweak(merkle_root), raw_tweak)
             tweak_point_want = S256Point.parse_xonly(
                 bytes.fromhex(test["intermediary"]["tweakedPubkey"])
             )
-            self.assertEqual(tap_root.xonly(), tweak_point_want.xonly())
+            external_pubkey = point.tweaked_key(merkle_root)
+            self.assertEqual(external_pubkey.xonly(), tweak_point_want.xonly())
             stream = BytesIO(
                 encode_varstr(bytes.fromhex(test["expected"]["scriptPubKey"]))
             )
             script_pubkey_want = ScriptPubKey.parse(stream)
-            self.assertEqual(tap_root.script_pubkey(), script_pubkey_want)
-            self.assertEqual(tap_root.address(), test["expected"]["bip350Address"])
+            self.assertEqual(point.p2tr_script(merkle_root), script_pubkey_want)
+            self.assertEqual(point.p2tr_address(merkle_root), test["expected"]["bip350Address"])
             control_blocks = test["expected"]["scriptPathControlBlocks"]
             leaf_hashes = test["intermediary"]["leafHashes"]
             for control_block_hex, tap_leaf, leaf_hash in zip(
@@ -314,16 +311,15 @@ class TaprootTest(TestCase):
                 self.assertEqual(tap_leaf.hash(), bytes.fromhex(leaf_hash))
                 control_block_raw = bytes.fromhex(control_block_hex)
                 control_block_want = ControlBlock.parse(control_block_raw)
-                control_block = tap_root.control_block(tap_leaf)
+                control_block = tap_tree.control_block(point, tap_leaf)
                 self.assertEqual(control_block, control_block_want)
                 self.assertEqual(
                     tap_leaf.tapleaf_version, control_block.tapleaf_version
                 )
-                self.assertEqual(tap_root.parity, control_block.parity)
                 self.assertEqual(control_block.serialize(), control_block_raw)
                 self.assertEqual(control_block.internal_pubkey, point)
-                self.assertEqual(control_block.merkle_root(tap_leaf), merkle_root)
-                self.assertEqual(control_block.tweak(tap_leaf), raw_tweak)
+                self.assertEqual(control_block.merkle_root(tap_leaf.tap_script), merkle_root)
+                self.assertEqual(control_block.internal_pubkey.tweak(merkle_root), raw_tweak)
 
     def test_p2tr_spending(self):
         test = {
@@ -582,15 +578,12 @@ class TaprootTest(TestCase):
             )
             mr_hex = input_data["given"]["merkleRoot"]
             if mr_hex is None:
-                merkle_root = None
+                merkle_root = b""
             else:
                 merkle_root = bytes.fromhex(mr_hex)
-            tap_root = TapRoot(pubkey, merkle_root=merkle_root)
-            tweak_want = big_endian_to_int(
-                bytes.fromhex(input_data["intermediary"]["tweak"])
-            )
-            self.assertEqual(tap_root.tweak, tweak_want)
-            tweaked_private_key = private_key.tweaked(tap_root.tweak)
+            tweak_want = bytes.fromhex(input_data["intermediary"]["tweak"])
+            self.assertEqual(pubkey.tweak(merkle_root), tweak_want)
+            tweaked_private_key = private_key.tweaked_key(merkle_root)
             tweaked_want = big_endian_to_int(
                 bytes.fromhex(input_data["intermediary"]["tweakedPrivkey"])
             )

--- a/buidl/test/test_taproot.py
+++ b/buidl/test/test_taproot.py
@@ -11,7 +11,6 @@ from buidl.taproot import (
     ControlBlock,
     TapLeaf,
     TapBranch,
-    TapRoot,
 )
 from buidl.tx import Tx
 from buidl.witness import Witness
@@ -26,7 +25,7 @@ class TaprootTest(TestCase):
         )
         t = TapRoot(point)
         self.assertEqual(
-            t.tweak_point.bip340().hex(),
+            t.tweak_point.xonly().hex(),
             "a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c",
         )
 
@@ -58,16 +57,16 @@ class TaprootTest(TestCase):
             },
         ]
         for test in tests:
-            point = S256Point.parse_bip340(
+            point = S256Point.parse_xonly(
                 bytes.fromhex(test["given"]["internalPubkey"])
             )
             raw_tweak = bytes.fromhex(test["intermediary"]["tweak"])
             tap_root = TapRoot(point)
             self.assertEqual(tap_root.tweak, big_endian_to_int(raw_tweak))
-            tweak_point_want = S256Point.parse_bip340(
+            tweak_point_want = S256Point.parse_xonly(
                 bytes.fromhex(test["intermediary"]["tweakedPubkey"])
             )
-            self.assertEqual(tap_root.bip340(), tweak_point_want.bip340())
+            self.assertEqual(tap_root.xonly(), tweak_point_want.xonly())
             stream = BytesIO(
                 encode_varstr(bytes.fromhex(test["expected"]["scriptPubKey"]))
             )
@@ -287,7 +286,7 @@ class TaprootTest(TestCase):
                 return TapBranch(parse_item(item[0]), parse_item(item[1]))
 
         for test in tests:
-            point = S256Point.parse_bip340(
+            point = S256Point.parse_xonly(
                 bytes.fromhex(test["given"]["internalPubkey"])
             )
             tap_tree = parse_item(test["given"]["scriptTree"])
@@ -297,10 +296,10 @@ class TaprootTest(TestCase):
             tap_root = TapRoot(point, tap_tree)
             raw_tweak = bytes.fromhex(test["intermediary"]["tweak"])
             self.assertEqual(tap_root.tweak, big_endian_to_int(raw_tweak))
-            tweak_point_want = S256Point.parse_bip340(
+            tweak_point_want = S256Point.parse_xonly(
                 bytes.fromhex(test["intermediary"]["tweakedPubkey"])
             )
-            self.assertEqual(tap_root.bip340(), tweak_point_want.bip340())
+            self.assertEqual(tap_root.xonly(), tweak_point_want.xonly())
             stream = BytesIO(
                 encode_varstr(bytes.fromhex(test["expected"]["scriptPubKey"]))
             )
@@ -579,7 +578,7 @@ class TaprootTest(TestCase):
             pubkey = private_key.point
             hash_type = input_data["given"]["hashType"]
             self.assertEqual(
-                pubkey.bip340().hex(), input_data["intermediary"]["internalPubkey"]
+                pubkey.xonly().hex(), input_data["intermediary"]["internalPubkey"]
             )
             mr_hex = input_data["given"]["merkleRoot"]
             if mr_hex is None:

--- a/buidl/timelock.py
+++ b/buidl/timelock.py
@@ -42,7 +42,7 @@ class Locktime(int):
         )
 
     def __lt__(self, other):
-        if type(other) == int:
+        if type(other) is int:
             return super().__lt__(other)
         if self.is_comparable(other):
             return super().__lt__(other)
@@ -108,7 +108,7 @@ class Sequence(int):
         )
 
     def __lt__(self, other):
-        if type(other) == int:
+        if type(other) is int:
             return super().__lt__(other)
         if self.is_comparable(other):
             return self & SEQUENCE_MASK < other & SEQUENCE_MASK

--- a/buidl/tx.py
+++ b/buidl/tx.py
@@ -649,7 +649,7 @@ tx_outs:\n{tx_outs}
             tx_in.witness = Witness(
                 [tap_script.raw_serialize(), control_block.serialize()]
             )
-            if type(tap_script) != MultiSigTapScript:
+            if type(tap_script) is not MultiSigTapScript:
                 raise RuntimeError("tap script must be MultiSigTapScript")
             tx_in.tap_script = tap_script
 

--- a/test_multiwallet.py
+++ b/test_multiwallet.py
@@ -15,7 +15,6 @@ class MultiwalletTest(unittest.TestCase):
         """
         buffer = ""
         while True:
-
             try:
                 # This will error out at the end of the buffer
                 latest_char = self.child.read(1)

--- a/test_singlesweep.py
+++ b/test_singlesweep.py
@@ -18,7 +18,6 @@ class SinglesweepTest(unittest.TestCase):
         """
         buffer = ""
         while True:
-
             try:
                 # This will error out at the end of the buffer
                 latest_char = self.child.read(1)


### PR DESCRIPTION
bip340 was not very descriptive, so that was changed to be xonly
The idea of a tweak was not very clear, instead the merkle root of the script path is a lot easier to reason about, so the code reflects this change. The terminology of internal pubkey and external pubkey is used to make it conceptually simpler. Similarly, a Tap Root is also not very clear, so we now use methods of a public key or a tapleaf/tapbranch to construct the needed external public keys and control blocks.