### PR TITLE
fix: pass correct int to op_1negate up to op_16 in encode_num, ScriptPubKey should accept stream and raw kwargs

### DIFF
--- a/buidl/op.py
+++ b/buidl/op.py
@@ -122,87 +122,87 @@ def op_0(stack):
 
 
 def op_1negate(stack):
-    stack.append(encode_num(-1))
+    stack.append(encode_num(79))
     return True
 
 
 def op_1(stack):
-    stack.append(encode_num(1))
+    stack.append(encode_num(81))
     return True
 
 
 def op_2(stack):
-    stack.append(encode_num(2))
+    stack.append(encode_num(82))
     return True
 
 
 def op_3(stack):
-    stack.append(encode_num(3))
+    stack.append(encode_num(83))
     return True
 
 
 def op_4(stack):
-    stack.append(encode_num(4))
+    stack.append(encode_num(84))
     return True
 
 
 def op_5(stack):
-    stack.append(encode_num(5))
+    stack.append(encode_num(85))
     return True
 
 
 def op_6(stack):
-    stack.append(encode_num(6))
+    stack.append(encode_num(86))
     return True
 
 
 def op_7(stack):
-    stack.append(encode_num(7))
+    stack.append(encode_num(87))
     return True
 
 
 def op_8(stack):
-    stack.append(encode_num(8))
+    stack.append(encode_num(88))
     return True
 
 
 def op_9(stack):
-    stack.append(encode_num(9))
+    stack.append(encode_num(89))
     return True
 
 
 def op_10(stack):
-    stack.append(encode_num(10))
+    stack.append(encode_num(90))
     return True
 
 
 def op_11(stack):
-    stack.append(encode_num(11))
+    stack.append(encode_num(91))
     return True
 
 
 def op_12(stack):
-    stack.append(encode_num(12))
+    stack.append(encode_num(92))
     return True
 
 
 def op_13(stack):
-    stack.append(encode_num(13))
+    stack.append(encode_num(93))
     return True
 
 
 def op_14(stack):
-    stack.append(encode_num(14))
+    stack.append(encode_num(94))
     return True
 
 
 def op_15(stack):
-    stack.append(encode_num(15))
+    stack.append(encode_num(95))
     return True
 
 
 def op_16(stack):
-    stack.append(encode_num(16))
+    stack.append(encode_num(96))
     return True
 
 

--- a/buidl/script.py
+++ b/buidl/script.py
@@ -353,8 +353,8 @@ class ScriptPubKey(Script):
     """Represents a ScriptPubKey in a transaction"""
 
     @classmethod
-    def parse(cls, s):
-        script_pubkey = super().parse(s)
+    def parse(cls, stream=None, raw=None):
+        script_pubkey = super().parse(stream, raw)
         if script_pubkey.is_p2pkh():
             return P2PKHScriptPubKey(script_pubkey.commands[2])
         elif script_pubkey.is_p2sh():


### PR DESCRIPTION
PR opened as per https://github.com/buidl-bitcoin/buidl-python/issues/159 and fixes the described issue.

```py
>>> TapScript.parse_hex('52935487')
OP_2 OP_ADD OP_4 OP_EQUAL 
>>> TapScript.parse_hex('52935487').raw_serialize().hex()
'52935487'
```

I've also changed the `ScriptPubKey`'s `parse` method so it accepts both `stream` and `raw` kwargs as inherited `Script` class handles, otherwise we get an error and in case `parse_hex()` method is used:

Before:
```py
>>> from io import BytesIO
>>> from buidl.taproot import TapScript
>>> TapScript.parse_hex('52935487')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "~/Documents/projects/bitcoin/buidl-python/buidl/script.py", line 116, in parse_hex
    return cls.parse(raw=bytes.fromhex(hex_str))
TypeError: ScriptPubKey.parse() got an unexpected keyword argument 'raw'
```

After:
```py
>>> from io import BytesIO
>>> from buidl.taproot import TapScript
>>> TapScript.parse_hex('52935487')
OP_2 OP_ADD OP_4 OP_EQUAL 
```

Let me know if it's ok. I will also be adding some test for above test cases.