### PR TITLE
support native segwit regtest addresses (#148)

### DIFF
--- a/buidl/script.py
+++ b/buidl/script.py
@@ -620,6 +620,13 @@ def address_to_script_pubkey(s):
         elif len(s) == 62:
             # p2wskh
             return P2WSHScriptPubKey(decode_bech32(s)[2])
+    elif s[:6] == "bcrt1q":
+        if len(s) == 44:
+            # p2wpkh
+            return P2WPKHScriptPubKey(decode_bech32(s)[2])
+        elif len(s) == 64:
+            # p2wsh
+            return P2WSHScriptPubKey(decode_bech32(s)[2])
     elif s[:4] in ("bc1p", "tb1p"):
         if len(s) != 62:
             raise RuntimeError(f"unknown type of address: {s}")

--- a/buidl/test/test_script.py
+++ b/buidl/test/test_script.py
@@ -227,6 +227,16 @@ class AddressToScriptPubKey(TestCase):
             ),
             (
                 P2WSHScriptPubKey,
+                "bcrt1qy0jn7qnt6tkmqq0yfhf00vr8yv4vf4y2232ppycaz29z7wjr23zq5m3kls",
+                "regtest",
+            ),
+            (
+                P2WPKHScriptPubKey,
+                "bcrt1qp58z6zvu64v8ntd3hpjl6eag40fjel0zkdfajs",
+                "regtest",
+            ),
+            (
+                P2WSHScriptPubKey,
                 "bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej",
                 "mainnet",
             ),


### PR DESCRIPTION
Add support for Native Segwit addresses on regtest networks

Resolves Issue #148


To verify this human readable part for bech32 regtest addresses, the following references may be helpful:
- [Bitcoin Core RegTestParams](https://github.com/bitcoin/bitcoin/blob/da10e0bab4a3e98868dd663af02c43b1dc8b7f4a/src/kernel/chainparams.cpp#L651)
- [BIP-0173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#segwit-address-format)
- [Implementation in `bitcoinjs-lib`](https://github.com/bitcoinjs/bitcoinjs-lib/blob/5137976e7b420500aaf37af52919d301b9b94c9b/src/networks.js#L15)