### PR TITLE
Add regtest address support to address_to_script_pubkey

### DIFF
--- a/buidl/script.py
+++ b/buidl/script.py
@@ -613,15 +613,16 @@ def address_to_script_pubkey(s):
         # p2sh
         h160 = decode_base58(s)
         return P2SHScriptPubKey(h160)
-    elif s[:4] in ("bc1q", "tb1q"):
-        if len(s) == 42:
+    elif s[:4] in ("bc1q", "tb1q") or s[:6] == "bcrt1q":
+        # regtest p2wpkh is len 44, p2wsh is len 64 (2 extra for "bcrt" vs "bc"/"tb")
+        if len(s) in (42, 44):
             # p2wpkh
             return P2WPKHScriptPubKey(decode_bech32(s)[2])
-        elif len(s) == 62:
-            # p2wskh
+        elif len(s) in (62, 64):
+            # p2wsh
             return P2WSHScriptPubKey(decode_bech32(s)[2])
-    elif s[:4] in ("bc1p", "tb1p"):
-        if len(s) != 62:
+    elif s[:4] in ("bc1p", "tb1p") or s[:6] == "bcrt1p":
+        if len(s) not in (62, 64):
             raise RuntimeError(f"unknown type of address: {s}")
         # p2tr
         return P2TRScriptPubKey(decode_bech32(s)[2])

--- a/buidl/test/test_script.py
+++ b/buidl/test/test_script.py
@@ -8,6 +8,7 @@ from buidl.script import (
     address_to_script_pubkey,
     P2PKHScriptPubKey,
     P2SHScriptPubKey,
+    P2TRScriptPubKey,
     P2WPKHScriptPubKey,
     P2WSHScriptPubKey,
     RedeemScript,
@@ -232,6 +233,32 @@ class AddressToScriptPubKey(TestCase):
             ),
             (P2SHScriptPubKey, "2MvVx9ccWqyYVNa5Xz9pfCEVk99zVBZh9ms", "testnet"),
             (P2PKHScriptPubKey, "1BenRpVUFK65JFWcQSuHnJKzc4M8ZP8Eqa", "mainnet"),
+        )
+        for scriptpubkey_type, addr, network in tests:
+            res = address_to_script_pubkey(addr)
+            self.assertEqual(scriptpubkey_type, type(res))
+            self.assertEqual(res.address(network=network), addr)
+
+    def test_address_to_script_pubkey_regtest(self):
+        tests = (
+            # regtest P2WPKH (bcrt1q..., length 44)
+            (
+                P2WPKHScriptPubKey,
+                "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080",
+                "regtest",
+            ),
+            # regtest P2WSH (bcrt1q..., length 64)
+            (
+                P2WSHScriptPubKey,
+                "bcrt1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qzf4jry",
+                "regtest",
+            ),
+            # regtest P2TR (bcrt1p..., length 64)
+            (
+                P2TRScriptPubKey,
+                "bcrt1prp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qg74mmc",
+                "regtest",
+            ),
         )
         for scriptpubkey_type, addr, network in tests:
             res = address_to_script_pubkey(addr)

--- a/buidl/test/test_tx.py
+++ b/buidl/test/test_tx.py
@@ -428,6 +428,13 @@ class TxTest(OfflineTestCase):
         self.assertIsNone(tx.coinbase_height())
 
 
+class TxFetcherRegtestTest(OfflineTestCase):
+    def test_get_url_regtest(self):
+        with self.assertRaises(ValueError) as cm:
+            TxFetcher.get_url("regtest")
+        self.assertIn("regtest", str(cm.exception))
+
+
 @skipUnless(
     getenv("INCLUDE_NETWORK_TESTS"),
     reason="Requires (unreliable) network connection",

--- a/buidl/tx.py
+++ b/buidl/tx.py
@@ -51,6 +51,11 @@ class TxFetcher:
 
     @classmethod
     def get_url(cls, network="mainnet"):
+        if network not in URL:
+            raise ValueError(
+                f"No URL available for network '{network}'. "
+                "TxFetcher only supports mainnet, testnet, and signet."
+            )
         return URL[network]
 
     @classmethod


### PR DESCRIPTION
## Summary

- `address_to_script_pubkey()` now handles regtest bech32 addresses (`bcrt1q` for P2WPKH/P2WSH, `bcrt1p` for P2TR)
- `TxFetcher.get_url()` raises a clear `ValueError` for regtest instead of an unhelpful `KeyError`
- Added tests for regtest address roundtrips and TxFetcher error handling

## Network parameter audit

Every function/method that takes `network` as a parameter was reviewed. Here is the full analysis:

### Dict lookup (regtest key exists in dict)

| File:Line | Function | How network is used | Regtest? |
|-----------|----------|-------------------|----------|
| `bech32.py:172` | `encode_bech32_checksum()` | `PREFIX.get(network)` | Yes — `PREFIX` has `"regtest": "bcrt"` |
| `network.py:43` | `GenericMessage.__init__()` | Stored, not branched | Yes |
| `network.py:52` | `GenericMessage.parse()` | `MAGIC[network]` | Yes — `MAGIC` has regtest |
| `network.py:306` | `SimpleNode.__init__()` | `PORT[network]` | Yes — `PORT` has regtest |
| `hd.py:141` | `HDPrivateKey.from_seed()` | `XPRV[network]` | Yes — `XPRV` has regtest |
| `tx.py:53` | `TxFetcher.get_url()` | `URL[network]` | **Fixed** — now raises clear `ValueError` |
| `tx.py:62` | `TxFetcher.fetch()` | Calls `get_url(network)` | **Fixed** via `get_url` |
| `tx.py:97` | `TxFetcher.sendrawtransaction()` | Calls `get_url(network)` | **Fixed** via `get_url` |

### Passthrough (stores or forwards `network`, no branching)

| File:Line | Function | How network is used |
|-----------|----------|-------------------|
| `cecc.py:368` | `PrivateKey.__init__()` | Stores `self.network` |
| `pecc.py:538` | `PrivateKey.__init__()` | Stores `self.network` |
| `cecc.py:215` | `S256Point.address()` | Forwards to `p2pkh_script().address(network)` |
| `cecc.py:219` | `S256Point.p2wpkh_address()` | Forwards to `p2wpkh_script().address(network)` |
| `cecc.py:223` | `S256Point.p2sh_p2wpkh_address()` | Forwards to `p2wpkh_script().p2sh_address(network)` |
| `cecc.py:227` | `S256Point.p2tr_address()` | Forwards to `p2tr_script().address(network)` |
| `pecc.py:339-351` | Same 4 methods on `S256Point` | Same as cecc.py |
| `script.py:428` | `RedeemScript.address()` | Forwards to `script_pubkey().address(network)` |
| `script.py:511` | `P2WPKHScriptPubKey.p2sh_address()` | Forwards to `redeem_script().address(network)` |
| `script.py:579` | `WitnessScript.p2sh_address()` | Forwards to `redeem_script().address(network)` |
| `tx.py:164-237` | `Tx.parse_hex/parse/parse_legacy/parse_segwit` | Stores `self.network` |
| `tx.py:864-878` | `TxIn.fetch_tx/value/script_pubkey` | Forwards to `TxFetcher.fetch(network)` |
| `psbt.py` (6 methods) | Various `parse()` methods | Stores or forwards, uses `path_network()` as fallback |
| `hd.py:273,695` | `raw_parse()` | Infers from xpub/xprv version bytes, override via param |

### Branching on `network == "mainnet"` (else = all non-mainnet including regtest)

| File:Line | Function | Logic | Regtest? |
|-----------|----------|-------|----------|
| `script.py:386` | `P2PKHScriptPubKey.address()` | mainnet → `0x00`, else → `0x6f` | Yes — regtest uses `0x6f` |
| `script.py:405` | `P2SHScriptPubKey.address()` | mainnet → `0x05`, else → `0xc4` | Yes — regtest uses `0xc4` |
| `script.py:504` | `P2WPKHScriptPubKey.address()` | Calls `encode_bech32_checksum(network)` | Yes |
| `script.py:545` | `P2WSHScriptPubKey.address()` | Calls `encode_bech32_checksum(network)` | Yes |
| `script.py:572` | `P2TRScriptPubKey.address()` | Calls `encode_bech32_checksum(network)` | Yes |

All mainnet-vs-else branches are correct for regtest because regtest shares testnet's base58 version bytes, and bech32 functions use the `PREFIX` dict which already includes regtest.

### Inherent protocol limitations (not bugs)

- **WIF parse** (`cecc.py:493`, `pecc.py:693`): WIF prefix `0xEF` is shared by testnet/signet/regtest — the format cannot distinguish them. `pecc.py` documents this explicitly.
- **`path_network()`** (`helper.py:360`): BIP32 paths use coin `1'` for all non-mainnet networks — cannot distinguish testnet/signet/regtest. PSBT callers allow explicit `network` override.

## Test plan
- [x] Regtest P2WPKH address (`bcrt1q...`, len 44) parses and roundtrips
- [x] Regtest P2WSH address (`bcrt1q...`, len 64) parses and roundtrips
- [x] Regtest P2TR address (`bcrt1p...`, len 64) parses and roundtrips
- [x] `TxFetcher.get_url("regtest")` raises `ValueError` with clear message
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)