### PR TITLE
Fix missing f-string prefixes on error messages

### DIFF
--- a/buidl/bcur.py
+++ b/buidl/bcur.py
@@ -85,7 +85,7 @@ def _parse_bcur_helper(bcur_string):
         y_int = int(xofy_parts[1])
 
         if x_int > y_int:
-            raise BCURStringFormatError("x must be >= y (in x-of-y): {xofy_parts}")
+            raise BCURStringFormatError(f"x must be >= y (in x-of-y): {xofy_parts}")
 
     else:
         raise BCURStringFormatError(f"{string} doesn't have 2-4 slashes")

--- a/buidl/descriptor.py
+++ b/buidl/descriptor.py
@@ -78,11 +78,11 @@ def parse_full_key_record(key_record_str):
     parts = key_record_str.split("/")
     if parts[-1] != "*":
         raise ValueError(
-            "Invalid full key record, does not end with a *: {key_record_str}"
+            f"Invalid full key record, does not end with a *: {key_record_str}"
         )
     if not is_intable(parts[-2]):
         raise ValueError(
-            "Invalid full key record, account index `{parts[-2]}` is not an int: {key_record_str}"
+            f"Invalid full key record, account index `{parts[-2]}` is not an int: {key_record_str}"
         )
 
     # Now we strip off the trailing account index and *, and parse the rest as a partial key record

--- a/buidl/hd.py
+++ b/buidl/hd.py
@@ -709,7 +709,7 @@ class HDPublicKey:
         elif pub_version in ALL_MAINNET_XPUBS:
             network = "mainnet"
         else:
-            raise ValueError("not a valid [t-z]pub pub_version: {pub_version}")
+            raise ValueError(f"not a valid [t-z]pub pub_version: {pub_version}")
         # the next byte is depth
         depth = byte_to_int(s.read(1))
         # next 4 bytes are the parent_fingerprint

--- a/buidl/psbt.py
+++ b/buidl/psbt.py
@@ -773,7 +773,7 @@ Extra:\n{self.extra_map}
 
         if not root_paths_for_signing:
             raise SuspiciousTransaction(
-                "No `root_paths_for_signing` with `hdpubkey_map` {hdpubkey_map} in PSBT:\n{self}"
+                f"No `root_paths_for_signing` with `hdpubkey_map` {hdpubkey_map} in PSBT:\n{self}"
             )
 
         return {


### PR DESCRIPTION
## Summary

Five error message strings contained `{variable}` interpolation syntax but were missing the `f` prefix, causing the literal text like `"{key_record_str}"` to appear in error messages instead of the actual variable value.

## Fixes

| File | Line | Error type | Variable(s) |
|------|------|-----------|-------------|
| `bcur.py` | 88 | `BCURStringFormatError` | `{xofy_parts}` |
| `descriptor.py` | 81 | `ValueError` | `{key_record_str}` |
| `descriptor.py` | 85 | `ValueError` | `{parts[-2]}`, `{key_record_str}` |
| `hd.py` | 712 | `ValueError` | `{pub_version}` |
| `psbt.py` | 776 | `SuspiciousTransaction` | `{hdpubkey_map}`, `{self}` |

## Test plan
- [x] These are all in error-raising paths — existing tests still pass
- [x] No behavioral change other than error messages now showing actual values

🤖 Generated with [Claude Code](https://claude.com/claude-code)